### PR TITLE
chore: Disable `@typescript-eslint/no-var-requires` rule for JS files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,7 +27,8 @@ module.exports = {
     {
       files: '*.js',
       rules: {
-        '@typescript-eslint/explicit-function-return-type': 'off'
+        '@typescript-eslint/explicit-function-return-type': 'off',
+        '@typescript-eslint/no-var-requires': 'off'
       }
     }
   ]


### PR DESCRIPTION
## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Code is reviewed for security
