### PR TITLE
fix: Make packages public

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,6 +6,9 @@
   "bin": {
     "axe": "axe-cli"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=8"
   },

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -8,6 +8,9 @@
   },
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "test": "mocha",

--- a/packages/reporter-earl/package.json
+++ b/packages/reporter-earl/package.json
@@ -10,6 +10,9 @@
     "build": "tsc",
     "prepublishOnly": "npm run build"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "coverageReporters": [
     "clover"
   ],

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -5,6 +5,9 @@
   "license": "MPL-2.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
   "contributors": [
     {
       "name": "Sushil Nagi",

--- a/packages/webdriverjs/package.json
+++ b/packages/webdriverjs/package.json
@@ -4,6 +4,9 @@
   "description": "Provides a method to inject and analyze web pages using aXe",
   "license": "MPL-2.0",
   "main": "dist/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "contributors": [
     {
       "name": "Dylan Barrell",


### PR DESCRIPTION
This patch makes the `@axe-core/*` packages _public_ rather than private.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Code is reviewed for security
