### PR TITLE
chore: make root-level fmt and lint use cross-plat compatible quotes

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "license": "MPL-2.0",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "fmt": "prettier --write *.{md,js,json} 'packages/**/*.{js,ts,tsx,html,json,md,css}'",
-    "lint": "eslint *.js 'packages/**/*.{js,ts,tsx}'",
+    "fmt": "prettier --write *.{md,js,json} \"packages/**/*.{js,ts,tsx,html,json,md,css}\"",
+    "lint": "eslint *.js \"packages/**/*.{js,ts,tsx}\"",
     "bootstrap": "lerna bootstrap"
   },
   "devDependencies": {


### PR DESCRIPTION
The root-level package.json's `fmt` and `lint` scripts were using single-quotes to encapsulate arguments, which works on linux but not windows. On Windows, the single quotes are treated as part of the argument, and so the glob patterns don't match anything. The old version gives an error like this:

```
> npm run lint

> axe-core-npm@ lint C:\repos\axe-core-npm
> eslint *.js 'packages/**/*.{js,ts,tsx}'


Oops! Something went wrong! :(

ESLint: 7.0.0

No files matching the pattern "'packages/**/*.{js,ts,tsx}'" were found.
Please check for typing mistakes in the pattern.

npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! axe-core-npm@ lint: `eslint *.js 'packages/**/*.{js,ts,tsx}'`
npm ERR! Exit status 2
npm ERR!
npm ERR! Failed at the axe-core-npm@ lint script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\danielbj\AppData\Roaming\npm-cache\_logs\2020-08-21T16_00_53_346Z-debug.log
```

Verified that after replacing the single quotes with double quotes, Windows and Ubuntu both give the same (expected) results.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Code is reviewed for security
