### PR TITLE
chore: add `dependabot` config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -31,11 +31,6 @@ update_configs:
     default_labels:
       - "axe_api_deps_bot"
   - package_manager: "javascript"
-    directory: "/packages/webdriverio"
-    update_schedule: "weekly"
-    default_labels:
-      - "axe_api_deps_bot"
-  - package_manager: "javascript"
     directory: "/packages/webdriverjs"
     update_schedule: "weekly"
     default_labels:

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,42 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "weekly"
+    default_labels:
+      - "axe_api_deps_bot"
+  - package_manager: "javascript"
+    directory: "/axe_core_test"
+    update_schedule: "weekly"
+    default_labels:
+      - "axe_api_deps_bot"
+  - package_manager: "javascript"
+    directory: "/packages/cli"
+    update_schedule: "weekly"
+    default_labels:
+      - "axe_api_deps_bot"
+  - package_manager: "javascript"
+    directory: "/packages/puppeteer"
+    update_schedule: "weekly"
+    default_labels:
+      - "axe_api_deps_bot"
+  - package_manager: "javascript"
+    directory: "/packages/react"
+    update_schedule: "weekly"
+    default_labels:
+      - "axe_api_deps_bot"
+  - package_manager: "javascript"
+    directory: "/packages/reporter-earl"
+    update_schedule: "weekly"
+    default_labels:
+      - "axe_api_deps_bot"
+  - package_manager: "javascript"
+    directory: "/packages/webdriverio"
+    update_schedule: "weekly"
+    default_labels:
+      - "axe_api_deps_bot"
+  - package_manager: "javascript"
+    directory: "/packages/webdriverjs"
+    update_schedule: "weekly"
+    default_labels:
+      - "axe_api_deps_bot"


### PR DESCRIPTION
This makes it easier to manage dependabot alerts than their UI.
> The `axe_api_deps_bot` label will help easily filter PR's opened by dependabot.


## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Code is reviewed for security
