### PR TITLE
chore(puppeteer): update axe-core to v4.1.0

### DIFF
--- a/packages/puppeteer/package-lock.json
+++ b/packages/puppeteer/package-lock.json
@@ -365,9 +365,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.0.1.tgz",
-      "integrity": "sha512-OSCABHvSNDleKqJP7DUwEBvMVbr/gtOj2vCDoKKz967fxe9WqtCZLo3IRNOO2fJcu+eSFsu8aAToHfIY7sPLaw=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.0.tgz",
+      "integrity": "sha512-9atDIOTDLsWL+1GbBec6omflaT5Cxh88J0GtJtGfCVIXpI02rXHkju59W5mMqWa7eiC5OR168v3TK3kUKBW98g=="
     },
     "balanced-match": {
       "version": "1.0.0",

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -42,7 +42,7 @@
     "typescript": "^3.1.6"
   },
   "dependencies": {
-    "axe-core": "^4.0.1"
+    "axe-core": "^4.1.0"
   },
   "peerDependencies": {
     "puppeteer": ">=1.10.0 < 6"


### PR DESCRIPTION
Blocked by: https://github.com/dequelabs/axe-core-npm/pull/161

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Code is reviewed for security
