### PR TITLE
chore(reporter-earl): update axe-core to v4.1.0

### DIFF
--- a/packages/reporter-earl/package-lock.json
+++ b/packages/reporter-earl/package-lock.json
@@ -540,9 +540,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.0.1.tgz",
-      "integrity": "sha512-OSCABHvSNDleKqJP7DUwEBvMVbr/gtOj2vCDoKKz967fxe9WqtCZLo3IRNOO2fJcu+eSFsu8aAToHfIY7sPLaw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.0.tgz",
+      "integrity": "sha512-9atDIOTDLsWL+1GbBec6omflaT5Cxh88J0GtJtGfCVIXpI02rXHkju59W5mMqWa7eiC5OR168v3TK3kUKBW98g==",
       "dev": true
     },
     "babel-code-frame": {

--- a/packages/reporter-earl/package.json
+++ b/packages/reporter-earl/package.json
@@ -30,7 +30,7 @@
     "@types/jest": "^23.3.9",
     "@types/jsonld": "github:types/jsonld",
     "@types/node": "^10.12.0",
-    "axe-core": "^4.0.1",
+    "axe-core": "^4.1.0",
     "clone": "^2.1.2",
     "jest": "^23.6.0",
     "jsonld": "^1.1.0",


### PR DESCRIPTION
Blocked by: https://github.com/dequelabs/axe-core-npm/pull/161

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Code is reviewed for security
