### PR TITLE
chore(webdriverjs): update axe-core to v4.1.0

### DIFF
--- a/packages/webdriverjs/package-lock.json
+++ b/packages/webdriverjs/package-lock.json
@@ -461,9 +461,9 @@
       "optional": true
     },
     "axe-core": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.0.1.tgz",
-      "integrity": "sha512-OSCABHvSNDleKqJP7DUwEBvMVbr/gtOj2vCDoKKz967fxe9WqtCZLo3IRNOO2fJcu+eSFsu8aAToHfIY7sPLaw=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.0.tgz",
+      "integrity": "sha512-9atDIOTDLsWL+1GbBec6omflaT5Cxh88J0GtJtGfCVIXpI02rXHkju59W5mMqWa7eiC5OR168v3TK3kUKBW98g=="
     },
     "axios": {
       "version": "0.19.2",

--- a/packages/webdriverjs/package.json
+++ b/packages/webdriverjs/package.json
@@ -77,7 +77,7 @@
     "sinon": "^7.3.2"
   },
   "dependencies": {
-    "axe-core": "^4.0.1",
+    "axe-core": "^4.1.0",
     "babel-runtime": "^6.26.0"
   },
   "nyc": {


### PR DESCRIPTION
Blocked by: https://github.com/dequelabs/axe-core-npm/pull/161

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Code is reviewed for security
