### PR TITLE
Handle undefined config when not specified

### DIFF
--- a/packages/react/index.ts
+++ b/packages/react/index.ts
@@ -355,7 +355,7 @@ function reactAxe(
   timeout = _timeout;
   context = _context;
 
-  const runOnly = conf['runOnly'];
+  const runOnly = (conf || {})['runOnly'];
   if (runOnly) {
     conf['rules'] = axeCore
       .getRules(runOnly)

--- a/packages/react/test/index.ts
+++ b/packages/react/test/index.ts
@@ -35,6 +35,9 @@ reactAxe(React, ReactDOM, 1000, {}, context);
 // axe-core context: string
 reactAxe(React, ReactDOM, 1000, {}, '#container');
 
+// axe-core undefined config
+reactAxe(React, ReactDOM, 1000, {}, undefined)
+
 // axe-core context: ContextObject
 reactAxe(
   React,


### PR DESCRIPTION
`react-axe` will fail with an exception if the configuration object is
not specified in the call to `axe()`:

A call like this:

```es6
axe(React, ReactDOM, 3000)
```

Throws an error like this:

```
index.js:374 Uncaught TypeError: Cannot read property 'runOnly' of undefined
    at reactAxe (index.js:374)
```

The existence of the configuration object is checked lower down in the
function, but the early check to see if `runOnly` is relevant doesn't work if
the object isn't there.

A workaround is to specify an empty object `{}`, but it seems from the
type definitions that this is truly meant to be an optional parameter.

Fix #176

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Code is reviewed for security
