### PR TITLE
docs(webdriverio): change loglevel to error in example

### DIFF
--- a/packages/webdriverio/README.md
+++ b/packages/webdriverio/README.md
@@ -34,7 +34,7 @@ const { remote } = require('webdriverio');
 
 (async () => {
   const client = await remote({
-    logLevel: 'silent',
+    logLevel: 'error',
     capabilities: {
       browserName: 'firefox'
     }

--- a/packages/webdriverio/README.md
+++ b/packages/webdriverio/README.md
@@ -34,6 +34,7 @@ const { remote } = require('webdriverio');
 
 (async () => {
   const client = await remote({
+    logLevel: 'silent',
     capabilities: {
       browserName: 'firefox'
     }


### PR DESCRIPTION
See: https://github.com/dequelabs/axe-core-npm/issues/216

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Code is reviewed for security
