### PR TITLE
fix(cli): add timeout waiting for page to be ready

### DIFF
--- a/packages/cli/src/lib/axe-test-urls.ts
+++ b/packages/cli/src/lib/axe-test-urls.ts
@@ -41,7 +41,8 @@ const testPages = async (
         return driver.wait(
           WebDriver.until.elementsLocated(
             WebDriver.By.css('.deque-axe-is-ready')
-          )
+          ),
+          10000
         );
       })
       .then(() => {


### PR DESCRIPTION
Partly addresses #230 

I discovered my CLI issue was because of the Content Security Policy (CSP) headers that I set in my web app. 
When I set `Content-Security-Policy` to `script-src 'unsafe-inline';`, AXE is then able to process the page.

This timeout is to force AXE to fail after 10 seconds of waiting; instead of indefinitely waiting for `.deque-axe-is-ready` (which will never be injected because of strict CSP headers in place).

**Sample output with timeout in place**
```console
Running axe-core 4.2.0 in chrome-headless

Testing http://example.com ... please wait, this may take a minute.
 
An error occurred while testing this page.
Please report the problem to: https://github.com/dequelabs/axe-cli/issues/
```