### PR TITLE
feat: respect explicit allowedOrigins configurations

### DIFF
--- a/packages/puppeteer/src/browser.ts
+++ b/packages/puppeteer/src/browser.ts
@@ -24,12 +24,15 @@ export function pageIsLoaded(): boolean {
 }
 
 export function configureAxe(config?: Axe.Spec): void {
+  window.axe.configure({
+    allowedOrigins: ['<unsafe_all_origins>']
+  });
+
   if (config) {
     window.axe.configure(config);
   }
 
   window.axe.configure({
-    allowedOrigins: ['<unsafe_all_origins>'],
     branding: { application: 'axe-puppeteer' }
   });
 }

--- a/packages/react/index.ts
+++ b/packages/react/index.ts
@@ -364,10 +364,11 @@ function reactAxe(
     conf['disableOtherRules'] = true;
   }
 
+  axeCore.configure({ allowedOrigins: ['<unsafe_all_origins>'] });
   if (Object.keys(conf).length > 0) {
     axeCore.configure(conf);
   }
-  axeCore.configure({ allowedOrigins: ['<unsafe_all_origins>'] });
+
   if (!_createElement) {
     _createElement = React.createElement;
 

--- a/packages/webdriverjs/src/axe-injector.ts
+++ b/packages/webdriverjs/src/axe-injector.ts
@@ -74,11 +74,9 @@ export default class AxeInjector {
   private get script(): string {
     return `
     ${this.axeSource}
-    ${this.config ? `axe.configure(${this.config})` : ''}
-    axe.configure({ 
-      allowedOrigins: ['<unsafe_all_origins>'], 
-      branding: { application: 'webdriverjs' }
-    })
+    axe.configure({ allowedOrigins: ['<unsafe_all_origins>'] });
+    ${this.config ? `axe.configure(${this.config});` : ''}
+    axe.configure({ branding: { application: 'webdriverjs' } });
     `;
   }
 

--- a/packages/webdriverjs/src/test/test.ts
+++ b/packages/webdriverjs/src/test/test.ts
@@ -103,6 +103,31 @@ describe('@axe-core/webdriverjs', () => {
       assert.equal(results.violations[0].nodes.length, 2);
     });
 
+    it('should not find violations in iframes prohibited by allowedOrigins', async () => {
+      const config = {
+        ...json,
+        allowedOrigins: ['http://not-our-iframe.example.com']
+      };
+
+      await driver.get(`${addr}/outer-configure-iframe.html`);
+      const results = await new AxeBuilder(driver)
+        .options({
+          rules: {
+            'landmark-one-main': { enabled: false },
+            'page-has-heading-one': { enabled: false },
+            region: { enabled: false },
+            'html-lang-valid': { enabled: false },
+            bypass: { enabled: false }
+          }
+        })
+        .configure(config)
+        .analyze();
+
+      assert.equal(results.violations[0].id, 'dylang');
+      // There is a second violation in a iframe which we should miss
+      assert.equal(results.violations[0].nodes.length, 1);
+    });
+
     it('should find configured violations in all frames', async () => {
       await driver.get(`${addr}/outer-configure-frame.html`);
       const results = await new AxeBuilder(driver)


### PR DESCRIPTION
#240 included a change to have the assorted integration libraries configure a default `allowedOrigins` policy, but in doing so, it overrides any explicitly-configured `allowedOrigins` settings configured by a library consumer. We have an `@axe-core/puppeteer` consumer (https://github.com/microsoft/accessibility-insights-service) where we'd like to be able to override the default policy; this PR implements that support by moving the configure call which sets the default to before the configure call with user-provided configuration.

Our team technically only needs this for `@axe-core/puppeteer`, but for consistency's sake I've included similar changes in each of the integration libraries which already included support for arbitrary `configure` calls (puppeteer, react, webdriverjs, but not webdriverio, since it doesn't appear to support an arbitrary configure spec).

We'd really appreciate if this could get in for the 4.2.1 release (@michael-siek , it looks like you're running this?) - we'd like to be able to use `allowedOrigins` as part of picking up v4.2.x if possible.