### PR TITLE
fix: pass chrome options to `chromeOptions.addArguments()` 

### DIFF
--- a/packages/cli/src/lib/webdriver.test.ts
+++ b/packages/cli/src/lib/webdriver.test.ts
@@ -64,15 +64,24 @@ describe('startDriver', () => {
     assert.equal((service as any).executable_, config.chromedriverPath);
   });
 
-  it('sets the --chrome-options flag with no-sandbox', async () => {
+  it('passes the --no-sandbox argument to chromeOptions', async () => {
     browser = 'chrome-headless';
-    config.chromeOptions = (['--no-sandbox'] as unknown) as Options[];
+    config.chromeOptions = ['--no-sandbox'];
     await startDriver(config);
-    const capabilities = config?.builder?.getCapabilities();
-    const chromeOptions = capabilities?.get('chromeOptions');
 
-    assert.isArray(chromeOptions.args);
-    assert.deepEqual(chromeOptions.args, ['--no-sandbox']);
+    const options = config?.builder?.getChromeOptions();
+    assert.isArray(options?.get("goog:chromeOptions").args);
+    assert.deepEqual(options?.get("goog:chromeOptions").args, ['headless', '--no-sandbox']);
+  });
+
+  it('passes multiple arguments argument to chromeOptions', async () => {
+    browser = 'chrome-headless';
+    config.chromeOptions = ['no-sandbox', 'disable-dev-shm-usage'];
+    await startDriver(config);
+
+    const options = config?.builder?.getChromeOptions();
+    assert.isArray(options?.get("goog:chromeOptions").args);
+    assert.deepEqual(options?.get("goog:chromeOptions").args, ['headless', 'no-sandbox', "disable-dev-shm-usage"]);
   });
 
   it('sets the --timeout flag', async () => {

--- a/packages/cli/src/lib/webdriver.ts
+++ b/packages/cli/src/lib/webdriver.ts
@@ -8,23 +8,23 @@ const startDriver = async (
 ): Promise<WebDriver> => {
   const scriptTimeout = (config.timeout || 20) * 1000.0;
   let builder: Builder;
-  const args: chrome.Options[] = [];
   /* istanbul ignore else */
   if (config.browser === 'chrome-headless') {
     const service = new chrome.ServiceBuilder(
       config.chromedriverPath || chromedriver.path
     ).build();
     chrome.setDefaultService(service);
+
+    let options = new chrome.Options().headless();
     if (config.chromeOptions?.length) {
-      args.push(...config.chromeOptions);
+      options = config.chromeOptions.reduce(function(options, arg) {
+        return options.addArguments(arg);
+      }, options );
     }
 
-    const chromeCapabilities = Capabilities.chrome();
-    chromeCapabilities.set('chromeOptions', { args });
     builder = new Builder()
       .forBrowser('chrome')
-      .withCapabilities(chromeCapabilities)
-      .setChromeOptions(new chrome.Options().headless());
+      .setChromeOptions(options);
   } else {
     builder = new Builder().forBrowser(config.browser);
   }

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -22,7 +22,7 @@ export interface WebdriverConfigParams {
   timeout?: number;
   chromedriverPath?: string;
   path?: string;
-  chromeOptions?: Options[];
+  chromeOptions?: string[];
   builder?: Builder;
 }
 


### PR DESCRIPTION
This PR should address https://github.com/dequelabs/axe-core-npm/issues/248

It updates 3 files to change how arguments are passed:

- Removes a now unnecessary cast from `packages/cli/src/types.ts`
- Changes how options are passed in `packages/cli/src/lib/webdriver.ts`
- Modifies test for option passing to match new behavior in `packages/cli/src/lib/webdriver.test.ts`
- Adds a test for multiple args in `packages/cli/src/lib/webdriver.test.ts`