### PR TITLE
chore(puppeteer): add perf script

### DIFF
--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "build": "tsc",
     "test": "mocha",
+    "test:perf": "npx ts-node test/perf.ts",
     "coverage": "nyc mocha",
     "prepublishOnly": "npm run build"
   },

--- a/packages/puppeteer/test/perf.ts
+++ b/packages/puppeteer/test/perf.ts
@@ -1,0 +1,48 @@
+import path from 'path';
+import fs from 'fs';
+import { performance } from 'perf_hooks';
+import Puppeteer from 'puppeteer';
+import AxePuppeteer from '../src/index';
+import { startServer, puppeteerArgs } from './utils';
+
+const axeSource = fs.readFileSync(require.resolve('axe-core'), 'utf8');
+const axeForceLegacyPath = path.resolve(
+  __dirname,
+  'fixtures/external/axe-force-legacy.js'
+);
+const axeForceLegacy = fs.readFileSync(axeForceLegacyPath, 'utf8');
+const runs = 100;
+
+(async () => {
+  const { server, addr } = await startServer();
+  const args = puppeteerArgs();
+  const browser = await Puppeteer.launch({ args });
+  const page = await browser.newPage();
+
+  // AxePuppeteer normal:
+  let total1 = 0;
+  console.log('Performance test runPartial');
+  for (let i = 0; i < runs; i++) {
+    await page.goto(`${addr}/context.html`);
+    const start = performance.now();
+    await new AxePuppeteer(page, axeSource).analyze();
+    total1 += performance.now() - start;
+  }
+
+  let total2 = 0;
+  console.log('starting test run');
+  for (let i = 0; i < runs; i++) {
+    await page.goto(`${addr}/context.html`);
+    const start = performance.now();
+    await new AxePuppeteer(page, axeSource + axeForceLegacy).analyze();
+    total2 += performance.now() - start;
+  }
+
+  console.log(
+    `Avg of AxePuppeteer running with axe.runPartial(): ${total1 / runs}`
+  );
+  console.log(`Avg of AxePuppeteer running with axe.run(): ${total2 / runs}`);
+
+  server.close();
+  await browser.close();
+})();


### PR DESCRIPTION
I wrote this, not sure if it's useful to keep, but I imagine it couldn't hurt.

When I run the script I get:

```
Avg of AxePuppeteer running with axe.runPartial(): 263.49406554818154
Avg of AxePuppeteer running with axe.run(): 89.11342667162418
```

That's on a page that's basically empty. I'm sure the difference will reduce on larger pages, and this perf timer doesn't account for page load time which makes this less obvious. I ran this script without running in about:blank and that takes of 200ms; which actually makes it faster than axe.run.

