### PR TITLE
chore(wdio): support shadow frames in devtools protocol

### DIFF
--- a/packages/webdriverio/src/index.ts
+++ b/packages/webdriverio/src/index.ts
@@ -18,7 +18,8 @@ import {
   axeGetFrameContext,
   axeRunPartial,
   axeFinishRun,
-  axeRunLegacy
+  axeRunLegacy,
+  axeShadowSelect
 } from './utils';
 
 export default class AxeBuilder {
@@ -312,8 +313,9 @@ export default class AxeBuilder {
       })
     ];
 
-    for (const { frameSelector, frameContext, frame } of frameContexts) {
+    for (const { frameSelector, frameContext } of frameContexts) {
       try {
+        const frame = await axeShadowSelect(this.client, frameSelector);
         assert(frame, `Expect frame of "${frameSelector}" to be defined`);
         await this.client.switchToFrame(frame);
         await axeSourceInject({

--- a/packages/webdriverio/src/test.ts
+++ b/packages/webdriverio/src/test.ts
@@ -766,6 +766,41 @@ describe('@axe-core/webdriverio', () => {
           );
         });
       });
+
+      describe('devtools protocol', () => {
+        let client: webdriverio.BrowserObject;
+        beforeEach(async () => {
+          client = await webdriverio.remote({
+            logLevel: 'error',
+            automationProtocol: 'devtools',
+            capabilities: {
+              browserName: 'chrome'
+            }
+          });
+        });
+
+        afterEach(() => {
+          client.deleteSession();
+        });
+
+        it('tests shadow DOM frames in with the devtools protocol', async () => {
+          await client.url(`${addr}/shadow-frames.html`);
+          const { violations } = await new AxeBuilder({ client })
+            .options({ runOnly: 'label' })
+            .analyze();
+
+          assert.equal(violations[0].id, 'label');
+          assert.lengthOf(violations[0].nodes, 3);
+
+          const nodes = violations[0].nodes;
+          assert.deepEqual(nodes[0].target, ['#light-frame', 'input']);
+          assert.deepEqual(nodes[1].target, [
+            ['#shadow-root', '#shadow-frame'],
+            'input'
+          ]);
+          assert.deepEqual(nodes[2].target, ['#slotted-frame', 'input']);
+        });
+      });
     });
   });
 


### PR DESCRIPTION
Fixes the issue that iframes in shadow DOM would not get tested when webdriverio was running in shadow DOM. 