### PR TITLE
fix(types): return `this` rather than the class

### DIFF
--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -36,10 +36,10 @@ export default class AxeBuilder {
    * Selector to include in analysis.
    * This may be called any number of times.
    * @param String selector
-   * @returns AxeBuilder
+   * @returns this
    */
 
-  public include(selector: string): AxeBuilder {
+  public include(selector: string): this {
     this.includes.push(selector);
     return this;
   }
@@ -48,10 +48,10 @@ export default class AxeBuilder {
    * Selector to exclude in analysis.
    * This may be called any number of times.
    * @param String selector
-   * @returns AxeBuilder
+   * @returns this
    */
 
-  public exclude(selector: string): AxeBuilder {
+  public exclude(selector: string): this {
     this.excludes.push(selector);
     return this;
   }
@@ -62,7 +62,7 @@ export default class AxeBuilder {
    * @returns AxeBuilder
    */
 
-  public options(options: RunOptions): AxeBuilder {
+  public options(options: RunOptions): this {
     this.option = options;
     return this;
   }
@@ -71,10 +71,10 @@ export default class AxeBuilder {
    * Limit analysis to only the specified rules.
    * Cannot be used with `AxeBuilder#withTags`
    * @param String|Array rules
-   * @returns AxeBuilder
+   * @returns this
    */
 
-  public withRules(rules: string | string[]): AxeBuilder {
+  public withRules(rules: string | string[]): this {
     rules = Array.isArray(rules) ? rules : [rules];
     /* istanbul ignore next */
     this.option = this.option || {};
@@ -90,10 +90,10 @@ export default class AxeBuilder {
    * Limit analysis to only specified tags.
    * Cannot be used with `AxeBuilder#withRules`
    * @param String|Array tags
-   * @returns AxeBuilder
+   * @returns this
    */
 
-  public withTags(tags: string | string[]): AxeBuilder {
+  public withTags(tags: string | string[]): this {
     tags = Array.isArray(tags) ? tags : [tags];
     /* istanbul ignore next */
     this.option = this.option || {};
@@ -107,10 +107,10 @@ export default class AxeBuilder {
   /**
    * Set the list of rules to skip when running an analysis.
    * @param String|Array rules
-   * @returns AxeBuilder
+   * @returns this
    */
 
-  public disableRules(rules: string | string[]): AxeBuilder {
+  public disableRules(rules: string | string[]): this {
     rules = Array.isArray(rules) ? rules : [rules];
     /* istanbul ignore next */
     this.option = this.option || {};

--- a/packages/webdriverio/src/index.ts
+++ b/packages/webdriverio/src/index.ts
@@ -47,10 +47,10 @@ export default class AxeBuilder {
    * Disable injecting axe-core into frame(s) matching the
    * given CSS `selector`. This method may be called any number of times.
    * @param {String} selector
-   * @returns {AxeBuilder}
+   * @returns {this}
    */
 
-  public disableFrame(selector: string): AxeBuilder {
+  public disableFrame(selector: string): this {
     this.disableFrameSelectors.push(cssesc(selector));
     return this;
   }
@@ -59,10 +59,10 @@ export default class AxeBuilder {
    * Selector to include in analysis.
    * This may be called any number of times.
    * @param {String} selector
-   * @returns {AxeBuilder}
+   * @returns {this}
    */
 
-  public include(selector: string): AxeBuilder {
+  public include(selector: string): this {
     this.includes.push(selector);
     return this;
   }
@@ -71,10 +71,10 @@ export default class AxeBuilder {
    * Selector to exclude in analysis.
    * This may be called any number of times.
    * @param {String} selector
-   * @returns {AxeBuilder}
+   * @returns {this}
    */
 
-  public exclude(selector: string): AxeBuilder {
+  public exclude(selector: string): this {
     this.excludes.push(selector);
     return this;
   }
@@ -82,10 +82,10 @@ export default class AxeBuilder {
   /**
    * Set options to be passed into axe-core
    * @param {RunOptions} options
-   * @returns {AxeBuilder}
+   * @returns {this}
    */
 
-  public options(options: RunOptions): AxeBuilder {
+  public options(options: RunOptions): this {
     this.option = options;
     return this;
   }
@@ -94,10 +94,10 @@ export default class AxeBuilder {
    * Limit analysis to only the specified rules.
    * Cannot be used with `AxeBuilder#withTags`
    * @param {String|Array} rules
-   * @returns {AxeBuilder}
+   * @returns {this}
    */
 
-  public withRules(rules: string | string[]): AxeBuilder {
+  public withRules(rules: string | string[]): this {
     rules = Array.isArray(rules) ? rules : [rules];
     /* istanbul ignore next */
     this.option = this.option || {};
@@ -113,10 +113,10 @@ export default class AxeBuilder {
    * Limit analysis to only specified tags.
    * Cannot be used with `AxeBuilder#withRules`
    * @param {String|Array} tags
-   * @returns {AxeBuilder}
+   * @returns {this}
    */
 
-  public withTags(tags: string | string[]): AxeBuilder {
+  public withTags(tags: string | string[]): this {
     tags = Array.isArray(tags) ? tags : [tags];
     /* istanbul ignore next */
     this.option = this.option || {};
@@ -130,10 +130,10 @@ export default class AxeBuilder {
   /**
    * Set the list of rules to skip when running an analysis.
    * @param {String|Array} rules
-   * @returns {AxeBuilder}
+   * @returns {this}
    */
 
-  public disableRules(rules: string | string[]): AxeBuilder {
+  public disableRules(rules: string | string[]): this {
     rules = Array.isArray(rules) ? rules : [rules];
     /* istanbul ignore next */
     this.option = this.option || {};

--- a/packages/webdriverjs/src/index.ts
+++ b/packages/webdriverjs/src/index.ts
@@ -40,7 +40,7 @@ class AxeBuilder {
    * Selector to include in analysis.
    * This may be called any number of times.
    */
-  public include(selector: string): AxeBuilder {
+  public include(selector: string): this {
     this.includes.push(selector);
     return this;
   }
@@ -49,7 +49,7 @@ class AxeBuilder {
    * Selector to exclude in analysis.
    * This may be called any number of times.
    */
-  public exclude(selector: string): AxeBuilder {
+  public exclude(selector: string): this {
     this.excludes.push(selector);
     return this;
   }
@@ -57,7 +57,7 @@ class AxeBuilder {
   /**
    * Set options to be passed into axe-core
    */
-  public options(options: RunOptions): AxeBuilder {
+  public options(options: RunOptions): this {
     this.option = options;
     return this;
   }
@@ -66,7 +66,7 @@ class AxeBuilder {
    * Limit analysis to only the specified rules.
    * Cannot be used with `AxeBuilder#withTags`
    */
-  public withRules(rules: string | string[]): AxeBuilder {
+  public withRules(rules: string | string[]): this {
     rules = Array.isArray(rules) ? rules : [rules];
     this.option.runOnly = {
       type: 'rule',
@@ -80,7 +80,7 @@ class AxeBuilder {
    * Limit analysis to only specified tags.
    * Cannot be used with `AxeBuilder#withRules`
    */
-  public withTags(tags: string | string[]): AxeBuilder {
+  public withTags(tags: string | string[]): this {
     tags = Array.isArray(tags) ? tags : [tags];
     this.option.runOnly = {
       type: 'tag',
@@ -92,7 +92,7 @@ class AxeBuilder {
   /**
    * Set the list of rules to skip when running an analysis.
    */
-  public disableRules(rules: string | string[]): AxeBuilder {
+  public disableRules(rules: string | string[]): this {
     rules = Array.isArray(rules) ? rules : [rules];
     this.option.rules = {};
     for (const rule of rules) {
@@ -105,7 +105,7 @@ class AxeBuilder {
    * Set configuration for `axe-core`.
    * This value is passed directly to `axe.configure()`
    */
-  public configure(config: Spec): AxeBuilder {
+  public configure(config: Spec): this {
     if (typeof config !== 'object') {
       throw new Error(
         'AxeBuilder needs an object to configure. See axe-core configure API.'


### PR DESCRIPTION
These need to return `this`, so that the classes can properly be extended. If we didn't return `this`, the following would be a problem:

```ts
class DevToolsWebdriverIO extends AxeBuilder {
  foo() {}
}
// foo does not exist on type AxeBuilder
new DevToolsWebdriverIO().include('foo').foo();
```