### PR TITLE
test(webdriverio): make sure to test `frame-tested`

### DIFF
--- a/packages/webdriverio/src/index.ts
+++ b/packages/webdriverio/src/index.ts
@@ -344,6 +344,7 @@ export default class AxeBuilder {
         partials.push(...(await this.runPartialRecursive(frameContext)));
       } catch (error) {
         partials.push(null);
+        await this.client.switchToParentFrame();
       }
     }
     await this.client.switchToParentFrame();


### PR DESCRIPTION
add frame testing from test fixtures

ref:https://github.com/dequelabs/axe-core-npm/issues/349