### PR TITLE
fix(webdriverJS): include/exclude chaining and iframe selectors

### DIFF
--- a/packages/webdriverjs/src/index.ts
+++ b/packages/webdriverjs/src/index.ts
@@ -1,7 +1,12 @@
 import { WebDriver } from 'selenium-webdriver';
 import { RunOptions, Spec, AxeResults, ContextObject } from 'axe-core';
 import { source } from 'axe-core';
-import { CallbackFunction, BuilderOptions, PartialResults } from './types';
+import {
+  CallbackFunction,
+  BuilderOptions,
+  PartialResults,
+  Selector
+} from './types';
 import { normalizeContext } from './utils/index';
 import AxeInjector from './axe-injector';
 import {
@@ -16,8 +21,8 @@ import * as assert from 'assert';
 class AxeBuilder {
   private driver: WebDriver;
   private axeSource: string;
-  private includes: string[][];
-  private excludes: string[][];
+  private includes: Selector[];
+  private excludes: Selector[];
   private option: RunOptions;
   private config: Spec | null;
   private builderOptions: BuilderOptions;
@@ -41,7 +46,7 @@ class AxeBuilder {
    * Selector to include in analysis.
    * This may be called any number of times.
    */
-  public include(selector: string | string[]): this {
+  public include(selector: Selector): this {
     selector = Array.isArray(selector) ? selector : [selector];
     this.includes.push(selector);
     return this;
@@ -51,7 +56,7 @@ class AxeBuilder {
    * Selector to exclude in analysis.
    * This may be called any number of times.
    */
-  public exclude(selector: string | string[]): this {
+  public exclude(selector: Selector): this {
     selector = Array.isArray(selector) ? selector : [selector];
     this.excludes.push(selector);
     return this;

--- a/packages/webdriverjs/src/index.ts
+++ b/packages/webdriverjs/src/index.ts
@@ -16,8 +16,8 @@ import * as assert from 'assert';
 class AxeBuilder {
   private driver: WebDriver;
   private axeSource: string;
-  private includes: string[];
-  private excludes: string[];
+  private includes: string[][];
+  private excludes: string[][];
   private option: RunOptions;
   private config: Spec | null;
   private builderOptions: BuilderOptions;
@@ -41,7 +41,8 @@ class AxeBuilder {
    * Selector to include in analysis.
    * This may be called any number of times.
    */
-  public include(selector: string): this {
+  public include(selector: string | string[]): this {
+    selector = Array.isArray(selector) ? selector : [selector];
     this.includes.push(selector);
     return this;
   }
@@ -50,8 +51,11 @@ class AxeBuilder {
    * Selector to exclude in analysis.
    * This may be called any number of times.
    */
-  public exclude(selector: string): this {
+  public exclude(selector: string | string[]): this {
+    selector = Array.isArray(selector) ? selector : [selector];
     this.excludes.push(selector);
+    console.log(this.excludes);
+
     return this;
   }
 

--- a/packages/webdriverjs/src/index.ts
+++ b/packages/webdriverjs/src/index.ts
@@ -54,8 +54,6 @@ class AxeBuilder {
   public exclude(selector: string | string[]): this {
     selector = Array.isArray(selector) ? selector : [selector];
     this.excludes.push(selector);
-    console.log(this.excludes);
-
     return this;
   }
 

--- a/packages/webdriverjs/src/types.ts
+++ b/packages/webdriverjs/src/types.ts
@@ -1,5 +1,5 @@
 import type { WebDriver } from 'selenium-webdriver';
-import type { Spec, AxeResults } from 'axe-core';
+import type { Spec, AxeResults, BaseSelector } from 'axe-core';
 import * as axe from 'axe-core';
 
 export interface Options {
@@ -25,3 +25,5 @@ export type CallbackFunction = (
 export type InjectCallback = (err?: Error) => void;
 
 export type PartialResults = Parameters<typeof axe.finishRun>[0];
+
+export type Selector = BaseSelector | BaseSelector[];

--- a/packages/webdriverjs/src/utils/index.ts
+++ b/packages/webdriverjs/src/utils/index.ts
@@ -4,20 +4,17 @@ import type { ContextObject } from 'axe-core';
  * Get running context
  */
 export const normalizeContext = (
-  include: string[],
-  exclude: string[]
+  include: string[][],
+  exclude: string[][]
 ): ContextObject => {
-  if (!exclude.length) {
-    if (!include.length) {
-      return { exclude: [] };
-    }
-    return { include };
-  }
-  if (!include.length) {
-    return { exclude };
-  }
-  return {
-    include,
-    exclude
+  const base: ContextObject = {
+    exclude: []
   };
+  if (exclude.length && Array.isArray(base.exclude)) {
+    base.exclude.push(...exclude);
+  }
+  if (include.length && Array.isArray(base.include)) {
+    base.include.push(...include);
+  }
+  return base;
 };

--- a/packages/webdriverjs/src/utils/index.ts
+++ b/packages/webdriverjs/src/utils/index.ts
@@ -13,8 +13,8 @@ export const normalizeContext = (
   if (exclude.length && Array.isArray(base.exclude)) {
     base.exclude.push(...exclude);
   }
-  if (include.length && Array.isArray(base.include)) {
-    base.include.push(...include);
+  if (include.length) {
+    base.include = include;
   }
   return base;
 };

--- a/packages/webdriverjs/src/utils/index.ts
+++ b/packages/webdriverjs/src/utils/index.ts
@@ -1,11 +1,12 @@
 import type { ContextObject } from 'axe-core';
+import { Selector } from '../types';
 
 /**
  * Get running context
  */
 export const normalizeContext = (
-  include: string[][],
-  exclude: string[][]
+  include: Selector[],
+  exclude: Selector[]
 ): ContextObject => {
   const base: ContextObject = {
     exclude: []

--- a/packages/webdriverjs/tests/axe-webdriverjs.spec.ts
+++ b/packages/webdriverjs/tests/axe-webdriverjs.spec.ts
@@ -1,5 +1,5 @@
 import 'mocha';
-import { Spec } from 'axe-core';
+import { AxeResults, Spec } from 'axe-core';
 import { WebDriver } from 'selenium-webdriver';
 import * as express from 'express';
 import * as chromedriver from 'chromedriver';
@@ -393,48 +393,94 @@ describe('@axe-core/webdriverjs', () => {
   });
 
   describe('include/exclude', () => {
+    const flatPassesTargets = (results: AxeResults): string[] => {
+      return results.passes
+        .reduce((acc, pass) => {
+          return acc.concat(pass.nodes as any);
+        }, [])
+        .reduce((acc, node: any) => {
+          return acc.concat(node.target);
+        }, []);
+    };
     it('with include and exclude', async () => {
-      let error: Error | null = null;
       await driver.get(`${addr}/context.html`);
       const builder = new AxeBuilder(driver)
         .include('.include')
         .exclude('.exclude');
+      const results = await builder.analyze();
 
-      try {
-        await builder.analyze();
-      } catch (e) {
-        error = e as Error;
-      }
-
-      assert.strictEqual(error, null);
+      assert.isTrue(flatPassesTargets(results).includes('.include'));
+      assert.isFalse(flatPassesTargets(results).includes('.exclude'));
     });
 
     it('with only include', async () => {
-      let error: Error | null = null;
       await driver.get(`${addr}/context.html`);
       const builder = new AxeBuilder(driver).include('.include');
+      const results = await builder.analyze();
 
-      try {
-        await builder.analyze();
-      } catch (e) {
-        error = e as Error;
-      }
-
-      assert.strictEqual(error, null);
+      assert.isTrue(flatPassesTargets(results).includes('.include'));
     });
 
     it('with only exclude', async () => {
-      let error: Error | null = null;
       await driver.get(`${addr}/context.html`);
       const builder = new AxeBuilder(driver).exclude('.exclude');
+      const results = await builder.analyze();
 
-      try {
-        await builder.analyze();
-      } catch (e) {
-        error = e as Error;
-      }
+      assert.isFalse(flatPassesTargets(results).includes('.exclude'));
+    });
 
-      assert.strictEqual(error, null);
+    it('with chaining only include', async () => {
+      await driver.get(`${addr}/context.html`);
+      const builder = new AxeBuilder(driver)
+        .include('.include')
+        .include('.include2');
+      const results = await builder.analyze();
+
+      assert.isTrue(flatPassesTargets(results).includes('.include'));
+      assert.isTrue(flatPassesTargets(results).includes('.include2'));
+    });
+
+    it('with chaining only exclude', async () => {
+      await driver.get(`${addr}/context.html`);
+      const builder = new AxeBuilder(driver)
+        .exclude('.exclude')
+        .exclude('.exclude2');
+      const results = await builder.analyze();
+
+      assert.isFalse(flatPassesTargets(results).includes('.exclude'));
+      assert.isFalse(flatPassesTargets(results).includes('.exclude2'));
+    });
+
+    it('with chaining only include and exclude', async () => {
+      await driver.get(`${addr}/context.html`);
+      const builder = new AxeBuilder(driver)
+        .include('.include')
+        .include('.include2')
+        .exclude('.exclude')
+        .exclude('.exclude2');
+      const results = await builder.analyze();
+      console.log(flatPassesTargets(results));
+
+      assert.isTrue(flatPassesTargets(results).includes('.include'));
+      assert.isTrue(flatPassesTargets(results).includes('.include2'));
+      assert.isFalse(flatPassesTargets(results).includes('.exclude'));
+      assert.isFalse(flatPassesTargets(results).includes('.exclude2'));
+    });
+
+    it('with chaining only include and exclude', async () => {
+      await driver.get(`${addr}/context.html`);
+      const builder = new AxeBuilder(driver)
+        .include('.include')
+        .include('.include2')
+        .exclude('.exclude')
+        .exclude('.exclude2');
+      const results = await builder.analyze();
+      console.log(flatPassesTargets(results));
+
+      assert.isTrue(flatPassesTargets(results).includes('.include'));
+      assert.isTrue(flatPassesTargets(results).includes('.include2'));
+      assert.isFalse(flatPassesTargets(results).includes('.exclude'));
+      assert.isFalse(flatPassesTargets(results).includes('.exclude2'));
     });
   });
 

--- a/packages/webdriverjs/tests/axe-webdriverjs.spec.ts
+++ b/packages/webdriverjs/tests/axe-webdriverjs.spec.ts
@@ -459,7 +459,6 @@ describe('@axe-core/webdriverjs', () => {
         .exclude('.exclude')
         .exclude('.exclude2');
       const results = await builder.analyze();
-      console.log(flatPassesTargets(results));
 
       assert.isTrue(flatPassesTargets(results).includes('.include'));
       assert.isTrue(flatPassesTargets(results).includes('.include2'));
@@ -475,12 +474,35 @@ describe('@axe-core/webdriverjs', () => {
         .exclude('.exclude')
         .exclude('.exclude2');
       const results = await builder.analyze();
-      console.log(flatPassesTargets(results));
 
       assert.isTrue(flatPassesTargets(results).includes('.include'));
       assert.isTrue(flatPassesTargets(results).includes('.include2'));
       assert.isFalse(flatPassesTargets(results).includes('.exclude'));
       assert.isFalse(flatPassesTargets(results).includes('.exclude2'));
+    });
+
+    it('with include / exclude iframe selectors with no violations', async () => {
+      await driver.get(`${addr}/context.html`);
+      const builder = new AxeBuilder(driver)
+        .include(['#ifr-one', 'html'])
+        .exclude(['#ifr-one', 'main'])
+        .exclude(['#ifr-one', 'img']);
+
+      const results = await builder.analyze();
+
+      assert.lengthOf(results.violations, 0);
+    });
+
+    it('with include / exclude iframe selectors with violations', async () => {
+      await driver.get(`${addr}/context.html`);
+      const builder = new AxeBuilder(driver)
+        .include(['#ifr-one', 'html'])
+        .exclude(['#ifr-one', 'main']);
+      const results = await builder.analyze();
+
+      assert.lengthOf(results.violations, 2);
+      assert.strictEqual(results.violations[0].id, 'image-alt');
+      assert.strictEqual(results.violations[1].id, 'region');
     });
   });
 

--- a/packages/webdriverjs/tests/axe-webdriverjs.spec.ts
+++ b/packages/webdriverjs/tests/axe-webdriverjs.spec.ts
@@ -451,7 +451,7 @@ describe('@axe-core/webdriverjs', () => {
       assert.isFalse(flatPassesTargets(results).includes('.exclude2'));
     });
 
-    it('with chaining only include and exclude', async () => {
+    it('with chaining include and exclude', async () => {
       await driver.get(`${addr}/context.html`);
       const builder = new AxeBuilder(driver)
         .include('.include')
@@ -466,22 +466,7 @@ describe('@axe-core/webdriverjs', () => {
       assert.isFalse(flatPassesTargets(results).includes('.exclude2'));
     });
 
-    it('with chaining only include and exclude', async () => {
-      await driver.get(`${addr}/context.html`);
-      const builder = new AxeBuilder(driver)
-        .include('.include')
-        .include('.include2')
-        .exclude('.exclude')
-        .exclude('.exclude2');
-      const results = await builder.analyze();
-
-      assert.isTrue(flatPassesTargets(results).includes('.include'));
-      assert.isTrue(flatPassesTargets(results).includes('.include2'));
-      assert.isFalse(flatPassesTargets(results).includes('.exclude'));
-      assert.isFalse(flatPassesTargets(results).includes('.exclude2'));
-    });
-
-    it('with include / exclude iframe selectors with no violations', async () => {
+    it('with include and exclude iframe selectors with no violations', async () => {
       await driver.get(`${addr}/context.html`);
       const builder = new AxeBuilder(driver)
         .include(['#ifr-one', 'html'])
@@ -493,7 +478,7 @@ describe('@axe-core/webdriverjs', () => {
       assert.lengthOf(results.violations, 0);
     });
 
-    it('with include / exclude iframe selectors with violations', async () => {
+    it('with include and exclude iframe selectors with violations', async () => {
       await driver.get(`${addr}/context.html`);
       const builder = new AxeBuilder(driver)
         .include(['#ifr-one', 'html'])

--- a/packages/webdriverjs/tests/fixtures/context.html
+++ b/packages/webdriverjs/tests/fixtures/context.html
@@ -6,6 +6,8 @@
   <body>
     <h1>Context Test</h1>
     <div class="include">include me</div>
+    <div class="include2">include me two</div>
     <div class="exclude">exclude me</div>
+    <div class="exclude2">exclude me two</div>
   </body>
 </html>

--- a/packages/webdriverjs/tests/fixtures/context.html
+++ b/packages/webdriverjs/tests/fixtures/context.html
@@ -9,5 +9,7 @@
     <div class="include2">include me two</div>
     <div class="exclude">exclude me</div>
     <div class="exclude2">exclude me two</div>
+
+    <iframe src="iframe-one.html" id="ifr-one"></iframe>
   </body>
 </html>

--- a/packages/webdriverjs/tests/fixtures/iframe-one.html
+++ b/packages/webdriverjs/tests/fixtures/iframe-one.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>iframe one</title>
+  </head>
+  <body>
+    <main>
+      <h1>iframe context test</h1>
+      <input />
+    </main>
+    <!-- to produce 1 violations -->
+    <img />
+  </body>
+</html>


### PR DESCRIPTION
Added support for method chaining on include and include as well as iframe CSS selectors. 

Refactored the current include/exclude tests to check if the results include / exclude the correct class. Used a function from [Playwright](https://github.com/dequelabs/axe-core-npm/blob/develop/packages/playwright/tests/axe-playwright.spec.ts#L377) that returns the node targets within a string array.

Examples: 

```js
// include and exclude
 const builder = new AxeBuilder(driver)
        .include('.include')
        .exclude('.exclude');
```
```js
// chaining include
const builder = new AxeBuilder(driver)
        .include('.include')
        .include('.include2');
```
```js
// chaining exclude
const builder = new AxeBuilder(driver)
        .exclude('.exclude')
        .exclude('.exclude2');
```
```js
// chaining include and exclude
const builder = new AxeBuilder(driver)
 		.include('.include')
        .include('.include2')
        .exclude('.exclude')
        .exclude('.exclude2');
```
```js
// iframe selectors
const builder = new AxeBuilder(driver)
        .include(['#ifr-one', 'html'])
        .exclude(['#ifr-one', 'main']);
```

Closes Issue: https://github.com/dequelabs/axe-core-npm/issues/332 (WDJS part)