### PR TITLE
ci: add create-release workflow

### DIFF
--- a/.github/scripts/prepare_release.sh
+++ b/.github/scripts/prepare_release.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Fail on first error.
+set -e
+
+releaseLevel="$1"
+
+npx lerna version "$releaseLevel" --conventional-commits --no-push --no-git-tag-version --yes

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,57 @@
+name: Create release candidate
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseLevel:
+        description: 'Release level: major, minor, or patch.'
+        required: true
+        default: 'patch'
+
+jobs:
+  create_release:
+    name: Create release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Run preparation script
+        run: bash .github/scripts/prepare_release.sh ${{ github.event.inputs.releaseLevel }}
+        env:
+          CHANGELOG_VERSION: ${{ secrets.CHANGELOG_VERSION }}
+          STD_VERSION_VERSION: ${{ secrets.STD_VERSION_VERSION }}
+
+      - name: Get version for later steps
+        id: get-new-version
+        run: echo ::set-output name=version::$(node -pe 'require("./lerna.json").version')
+
+      - name: Create release commit
+        run: |
+          git config user.name "${{ secrets.ADT_API_RELEASE_NAME }}"
+          git config user.email "${{ secrets.ADT_API_RELEASE_EMAIL }}"
+          git commit -am "chore: release v${{ steps.get-new-version.outputs.version }}"
+      # create-pull-request has no way of setting the target branch that won't also
+      # get rid of all commits (aside from the release commit).
+      # So, we have to be on master and manually grab all the changes.
+      # We do that by just telling git "master is now develop (+ the release commit)".
+      - name: Update local master from develop
+        run: |
+          commitHash="$(git log -1 --format='%H')"
+          git checkout master
+          git reset --hard "$commitHash"
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: release
+          branch-suffix: timestamp
+          base: master
+          title: "chore: release v${{ steps.get-new-version.outputs.version }}"
+          # If there are any changes not already committed, they will be added to
+          # a commit with this as the message.
+          # If there are no changes no commit will be created.
+          commit-message: "chore: applying release changes"


### PR DESCRIPTION
No real way of testing this until it gets merged and the "Create Release" action can be used.

Requires the following variables added to secrets:

* CHANGELOG_VERSION - Used for changelog
* STD_VERSION_VERSION - Used for changelog
* ADT_API_RELEASE_NAME - Used only for git commit
* ADT_API_RELEASE_EMAIL - Used only for git commit