### PR TITLE
fix(cli): pass chromedriver-path arg to webdriver

### DIFF
--- a/packages/cli/src/bin/cli.test.ts
+++ b/packages/cli/src/bin/cli.test.ts
@@ -315,4 +315,18 @@ describe('cli', () => {
       }
     });
   });
+
+  describe('--chromedriver-path', () => {
+    it('should throw error if path does not exist', async () => {
+      const result = await runCLI(
+        `file://${SIMPLE_HTML_FILE}`,
+        '--chromedriver-path="someinvalidpath"',
+        '--show-errors'
+      );
+      assert.include(
+        result.stderr,
+        'The specified executable path does not exist'
+      );
+    });
+  });
 });

--- a/packages/cli/src/bin/index.ts
+++ b/packages/cli/src/bin/index.ts
@@ -37,7 +37,8 @@ const cli = async (
     tags,
     rules,
     disable,
-    loadDelay
+    loadDelay,
+    chromedriverPath
   } = args;
 
   const silentMode = !!stdout;
@@ -66,7 +67,7 @@ const cli = async (
     browser: args.browser,
     timeout,
     chromeOptions,
-    path
+    chromedriverPath
   };
 
   args.driver = startDriver(driverConfigs);

--- a/packages/cli/src/bin/index.ts
+++ b/packages/cli/src/bin/index.ts
@@ -31,7 +31,6 @@ const cli = async (
     chromeOptions,
     verbose,
     timeout,
-    path,
     include,
     exclude,
     tags,


### PR DESCRIPTION
We were not passing the `--chromedriver-path` arg value to webdriver. 

Within `webdriver.ts` `config.chromedriverPath` would produce undefined even if `--chromedriver-path` was set which would result in using the default chrome driver and not the one set by the user.

![image](https://user-images.githubusercontent.com/41127686/148275277-60488a7a-e1e9-4efe-9f08-1babcb5e2c7e.png)
  
If we add `chromedriverPath` to the destructured args and a user provides an invalid path we do error correctly throw the error as well as use the given Chrome driver: 

Invalid Path:

![image](https://user-images.githubusercontent.com/41127686/148275819-442ca093-c49d-4232-a840-ad028adfb94e.png)

Valid Path: 

![image](https://user-images.githubusercontent.com/41127686/148276492-e1e22134-b289-448b-b32b-81bfeb0cd4ed.png)


Note:  `--chromedriver-path` does not seem to support backwards compatibility in terms of Chrome Driver, it depends on your personal Chrome version. Example, if you're using V96 you cannot use V95 chrome driver, otherwise you will get a session error (as shown in the issue referenced).

Closes issue: https://github.com/dequelabs/axe-core-npm/issues/370
