### PR TITLE
@axe-core/react: includes source-maps to dist

### DIFF
--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -4,6 +4,7 @@
     "moduleResolution": "node",
     "declaration": true,
     "sourceMap": true,
+    "inlineSources": true,
     "allowJs": false,
     "module": "commonjs",
     "target": "es5",


### PR DESCRIPTION
`@axe-core/react` dist folder contains generated `*.js.map` files with non-existing references to `.ts` files and can produce warnings e.g. see #414. This will ensure the source map files are inlined into `*.js.map` hence included in dist.

Closes #414.