### PR TITLE
fix(cli): provide a more robust error message if analysis fails

### DIFF
--- a/packages/cli/src/bin/cli.test.ts
+++ b/packages/cli/src/bin/cli.test.ts
@@ -185,7 +185,8 @@ describe('cli', () => {
       const result = await runCLI(
         `file://${SIMPLE_HTML_FILE}`,
         '--include',
-        '#hazaar'
+        '#hazaar',
+        '--show-errors'
       );
 
       assert.include(
@@ -199,7 +200,8 @@ describe('cli', () => {
       const result = await runCLI(
         `file://${SIMPLE_HTML_FILE}`,
         '--include',
-        '#123'
+        '#123',
+        '--show-errors'
       );
 
       assert.include(result.stderr, 'is not a valid selector');
@@ -224,7 +226,8 @@ describe('cli', () => {
       const result = await runCLI(
         `file://${SIMPLE_HTML_FILE}`,
         '--exclude',
-        '#123'
+        '#123',
+        '--show-errors'
       );
 
       assert.include(result.stderr, 'is not a valid selector');

--- a/packages/cli/src/bin/cli.test.ts
+++ b/packages/cli/src/bin/cli.test.ts
@@ -181,7 +181,7 @@ describe('cli', () => {
       );
     });
 
-    it('should throw error is CSS selector is not found', async () => {
+    it('should throw error if CSS selector is not found', async () => {
       const result = await runCLI(
         `file://${SIMPLE_HTML_FILE}`,
         '--include',
@@ -192,6 +192,7 @@ describe('cli', () => {
         result.stderr,
         'javascript error: No elements found for include in page Context'
       );
+      assert.equal(result.exitCode, 1);
     });
 
     it('should throw error if invalid selector is provided', async () => {
@@ -202,6 +203,7 @@ describe('cli', () => {
       );
 
       assert.include(result.stderr, 'is not a valid selector');
+      assert.equal(result.exitCode, 1);
     });
   });
 
@@ -226,6 +228,7 @@ describe('cli', () => {
       );
 
       assert.include(result.stderr, 'is not a valid selector');
+      assert.equal(result.exitCode, 1);
     });
   });
 

--- a/packages/cli/src/bin/cli.test.ts
+++ b/packages/cli/src/bin/cli.test.ts
@@ -180,6 +180,29 @@ describe('cli', () => {
         'Violation of "marquee" with 1 occurrences!'
       );
     });
+
+    it('should throw error is CSS selector is not found', async () => {
+      const result = await runCLI(
+        `file://${SIMPLE_HTML_FILE}`,
+        '--include',
+        '#hazaar'
+      );
+
+      assert.include(
+        result.stderr,
+        'javascript error: No elements found for include in page Context'
+      );
+    });
+
+    it('should throw error if invalid selector is provided', async () => {
+      const result = await runCLI(
+        `file://${SIMPLE_HTML_FILE}`,
+        '--include',
+        '#123'
+      );
+
+      assert.include(result.stderr, 'is not a valid selector');
+    });
   });
 
   describe('--exclude', () => {
@@ -193,6 +216,16 @@ describe('cli', () => {
         result.stdout,
         'Violation of "marquee" with 1 occurrences!'
       );
+    });
+
+    it('should throw error if invalid selector is provided', async () => {
+      const result = await runCLI(
+        `file://${SIMPLE_HTML_FILE}`,
+        '--exclude',
+        '#123'
+      );
+
+      assert.include(result.stderr, 'is not a valid selector');
     });
   });
 

--- a/packages/cli/src/bin/index.ts
+++ b/packages/cli/src/bin/index.ts
@@ -150,7 +150,7 @@ const cli = async (
     if (!showErrors) {
       console.error(error('An error occurred while testing this page.'));
     } else {
-      console.error(error('Error: %j \n $s'), e.message, e.stack);
+      console.error(error('Error: %s'), e);
     }
 
     console.error(

--- a/packages/cli/src/lib/axe-test-urls.ts
+++ b/packages/cli/src/lib/axe-test-urls.ts
@@ -1,7 +1,6 @@
 import * as WebDriver from 'selenium-webdriver';
 import AxeBuilder from '@axe-core/webdriverjs';
 import { AxeResults } from 'axe-core';
-import { error } from '../lib/utils';
 import { EventResponse, ConfigParams } from '../types';
 
 const testPages = async (

--- a/packages/cli/src/lib/axe-test-urls.ts
+++ b/packages/cli/src/lib/axe-test-urls.ts
@@ -1,6 +1,7 @@
 import * as WebDriver from 'selenium-webdriver';
 import AxeBuilder from '@axe-core/webdriverjs';
 import { AxeResults } from 'axe-core';
+import { error } from '../lib/utils';
 import { EventResponse, ConfigParams } from '../types';
 
 const testPages = async (
@@ -91,6 +92,7 @@ const testPages = async (
 
           /* istanbul ignore if */
           if (err) {
+            console.error(error(err));
             return reject(err);
           }
 

--- a/packages/cli/src/lib/axe-test-urls.ts
+++ b/packages/cli/src/lib/axe-test-urls.ts
@@ -92,8 +92,7 @@ const testPages = async (
 
           /* istanbul ignore if */
           if (err) {
-            console.error(error(err));
-            process.exit(1);
+            return reject(err);
           }
 
           // Notify about the update

--- a/packages/cli/src/lib/axe-test-urls.ts
+++ b/packages/cli/src/lib/axe-test-urls.ts
@@ -93,7 +93,7 @@ const testPages = async (
           /* istanbul ignore if */
           if (err) {
             console.error(error(err));
-            return reject(err);
+            process.exit(1);
           }
 
           // Notify about the update


### PR DESCRIPTION
The use of `--include` and providing an non-existent or invalid CSS selector would not notify user that was the case: 

![image](https://user-images.githubusercontent.com/41127686/148812667-47f26289-c963-4182-b9cf-ae590df470a5.png)
![image](https://user-images.githubusercontent.com/41127686/148812692-0d36dcc4-1728-4315-b3c0-68a43c1cc0bb.png)


Providing an non-existent or invalid CSS selector will now notify the user of said error: 

![image](https://user-images.githubusercontent.com/41127686/148813591-81d6568c-914c-464a-931d-fdc820f3001a.png)




Closes issue: https://github.com/dequelabs/axe-core-npm/issues/207