### PR TITLE
fix(webdriverjs): Reject with actual `Error`s (not strings)

### DIFF
--- a/packages/cli/src/bin/index.ts
+++ b/packages/cli/src/bin/index.ts
@@ -150,7 +150,7 @@ const cli = async (
     if (!showErrors) {
       console.error(error('An error occurred while testing this page.'));
     } else {
-      console.error(error('Error: %s \n%s'), e.message, e.stack);
+      console.error(error('Error: %s\n%s'), e.message, e.stack);
     }
 
     console.error(

--- a/packages/cli/src/bin/index.ts
+++ b/packages/cli/src/bin/index.ts
@@ -150,7 +150,7 @@ const cli = async (
     if (!showErrors) {
       console.error(error('An error occurred while testing this page.'));
     } else {
-      console.error(error('Error: %j \n $s'), e.message, e.stack);
+      console.error(error('Error: %s \n%s'), e.message, e.stack);
     }
 
     console.error(

--- a/packages/cli/src/lib/axe-test-urls.ts
+++ b/packages/cli/src/lib/axe-test-urls.ts
@@ -30,11 +30,11 @@ const testPages = async (
       .get(currentUrl)
       .then(() => {
         return driver.executeAsyncScript(`
-      const callback = arguments[arguments.length - 1];
-      const script = document.createElement('script');
-      script.innerHTML = 'document.documentElement.classList.add("deque-axe-is-ready");'
-      document.documentElement.appendChild(script);
-      callback();
+          const callback = arguments[arguments.length - 1];
+          const script = document.createElement('script');
+          script.innerHTML = 'document.documentElement.classList.add("deque-axe-is-ready");'
+          document.documentElement.appendChild(script);
+          callback();
       `);
       })
       .then(() => {
@@ -84,7 +84,7 @@ const testPages = async (
           events?.startTimer('axe-core execution time');
         }
 
-        axe.analyze((err: string, results: AxeResults) => {
+        axe.analyze((err: Error | null, results: AxeResults) => {
           if (config.timer) {
             events?.endTimer('axe-core execution time');
           }

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,6 +1,6 @@
 import type { AxeResults } from 'axe-core';
 import type { WebDriver, Builder } from 'selenium-webdriver';
-import type { Options } from 'selenium-webdriver/chrome';
+
 export interface EventParams {
   silentMode: boolean;
   timer: boolean;

--- a/packages/webdriverjs/src/index.ts
+++ b/packages/webdriverjs/src/index.ts
@@ -1,12 +1,7 @@
 import { WebDriver } from 'selenium-webdriver';
 import { RunOptions, Spec, AxeResults, ContextObject } from 'axe-core';
 import { source } from 'axe-core';
-import {
-  CallbackFunction,
-  BuilderOptions,
-  PartialResults,
-  Selector
-} from './types';
+import { CallbackFunction, BuilderOptions, Selector } from './types';
 import { normalizeContext } from './utils/index';
 import AxeInjector from './axe-injector';
 import {
@@ -136,7 +131,7 @@ class AxeBuilder {
         .catch((err: Error) => {
           // When using a callback, do *not* reject the wrapping Promise. This prevents having to handle the same error twice.
           if (callback) {
-            callback(err.message, null);
+            callback(err, null);
           } else {
             reject(err);
           }

--- a/packages/webdriverjs/src/types.ts
+++ b/packages/webdriverjs/src/types.ts
@@ -18,7 +18,7 @@ export interface AxeInjectorParams extends Options {
 }
 
 export type CallbackFunction = (
-  error: string | null,
+  error: Error | null,
   results: AxeResults | null
 ) => void;
 


### PR DESCRIPTION
This patch updates the error handling in `@axe-core/webdriverjs`, having it return an actual `Error` rather than a string. Rejecting/returning a string (eg `error.message`) leads to tons of bugs/confusion. Providing the `Error` to the caller enables a much richer debugging experience.

Closes #422
Ref #421
Ref #387
Ref #308 (somewhat)
Ref #207