### PR TITLE
ci: update circleci image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,8 +157,8 @@ jobs:
     steps:
       - checkout
       - restore_dependency_cache
-      - run: npx browser-driver-manager@1.0.4 install chrome chromedriver
       - run: npm --prefix=packages/webdriverjs run build
+      - run: npx browser-driver-manager@1.0.4 install chrome chromedriver
       - run: npm run test --prefix=packages/webdriverjs/tests/example
 
   webdriverio:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 defaults: &defaults
   docker:
-    - image: circleci/node:12-browsers
+    - image: cimg/node:16.14-browsers
   working_directory: ~/axe-core-npm
 
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,8 +157,8 @@ jobs:
     steps:
       - checkout
       - restore_dependency_cache
-      - run: npm --prefix=packages/webdriverjs run build
       - run: npx browser-driver-manager@1.0.4 install chrome chromedriver
+      - run: npm --prefix=packages/webdriverjs/tests/example run build
       - run: npm run test --prefix=packages/webdriverjs/tests/example
 
   webdriverio:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,8 +157,9 @@ jobs:
     steps:
       - checkout
       - restore_dependency_cache
-      - run: npx browser-driver-manager@1.0.4 install chrome chromedriver
-      - run: npm --prefix=packages/webdriverjs/tests/example run build
+      - run: npm --prefix=packages/webdriverjs run build
+      - run: npm install browser-driver-manager@1.0.4 install chrome chromedriver
+      - run: npx lerna link
       - run: npm run test --prefix=packages/webdriverjs/tests/example
 
   webdriverio:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,8 @@ version: 2.1
 
 defaults: &defaults
   docker:
+    # using a node14 image instead of a node16 image due to WDIO
+    # @see https://webdriver.io/blog/2021/07/28/sync-api-deprecation/
     - image: cimg/node:14.19-browsers
   working_directory: ~/axe-core-npm
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  browser-tools: circleci/browser-tools@1.2.4
+
 defaults: &defaults
   docker:
     # using a node14 image instead of a node16 image due to WDIO
@@ -157,9 +160,9 @@ jobs:
     steps:
       - checkout
       - restore_dependency_cache
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - run: npm --prefix=packages/webdriverjs run build
-      - run: npm install browser-driver-manager@1.0.4 install chrome chromedriver
-      - run: npx lerna link
       - run: npm run test --prefix=packages/webdriverjs/tests/example
 
   webdriverio:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 defaults: &defaults
   docker:
-    - image: cimg/node:16.14-browsers
+    - image: cimg/node:14.19-browsers
   working_directory: ~/axe-core-npm
 
 commands:
@@ -155,6 +155,7 @@ jobs:
     steps:
       - checkout
       - restore_dependency_cache
+      - run: npx browser-driver-manager@1.0.4 install chrome chromedriver
       - run: npm --prefix=packages/webdriverjs run build
       - run: npm run test --prefix=packages/webdriverjs/tests/example
 


### PR DESCRIPTION
Update images due to [CircleCI deprecating old images](https://circleci.com/docs/2.0/next-gen-migration-guide/?mkt_tok=NDg1LVpNSC02MjYAAAGDBUMk7dU_Zxw5fNTv_3DBe5GFhHC4kabmviar7bwOL2wXKiq7WNQbs_o2L_ThnHD4j99jXTGTwwnzHGapRF42im_gQLAvhVukDaQX4qnHiOpcrw#overview)