### PR TITLE
fix(react): revert export to not use default

### DIFF
--- a/packages/react/cache.ts
+++ b/packages/react/cache.ts
@@ -14,4 +14,4 @@ const cache = {
   }
 };
 
-export = cache;
+export default cache;

--- a/packages/react/cache.ts
+++ b/packages/react/cache.ts
@@ -1,12 +1,6 @@
 const _cache: { [key: string]: string } = {};
 
-interface Cache {
-  set(key: string, value: string): void;
-  get(key: string): string;
-  clear(): void;
-}
-
-const cache: Cache = {
+const cache = {
   set(key: string, value: string): void {
     _cache[key] = value;
   },

--- a/packages/react/cache.ts
+++ b/packages/react/cache.ts
@@ -1,0 +1,23 @@
+const _cache: { [key: string]: string } = {};
+
+interface Cache {
+  set(key: string, value: string): void;
+  get(key: string): string;
+  clear(): void;
+}
+
+const cache: Cache = {
+  set(key: string, value: string): void {
+    _cache[key] = value;
+  },
+  get(key: string): string {
+    return _cache[key];
+  },
+  clear(): void {
+    Object.keys(_cache).forEach(key => {
+      delete _cache[key];
+    });
+  }
+};
+
+export = cache;

--- a/packages/react/index.ts
+++ b/packages/react/index.ts
@@ -2,7 +2,7 @@
 import axeCore = require('axe-core');
 import rIC = require('requestidlecallback');
 import after = require('./after');
-import cache = require('./cache');
+import cache from './cache';
 
 const requestIdleCallback = rIC.request;
 const cancelIdleCallback = rIC.cancel;

--- a/packages/react/index.ts
+++ b/packages/react/index.ts
@@ -2,6 +2,7 @@
 import axeCore = require('axe-core');
 import rIC = require('requestidlecallback');
 import after = require('./after');
+import cache = require('./cache');
 
 const requestIdleCallback = rIC.request;
 const cancelIdleCallback = rIC.cancel;
@@ -43,7 +44,6 @@ let conf: ReactSpec;
 let _createElement: typeof React.createElement;
 const components: { [id: number]: React.Component } = {};
 const nodes: Node[] = [document.documentElement];
-const cache: { [key: string]: string } = {};
 
 // Returns a function, that, as long as it continues to be invoked, will not
 // be triggered. The function will be called after it stops being called for
@@ -221,8 +221,8 @@ function checkAndReport(node: Node, timeout: number): Promise<void> {
             results.violations = results.violations.filter(result => {
               result.nodes = result.nodes.filter(node => {
                 const key: string = node.target.toString() + result.id;
-                const retVal = !cache[key];
-                cache[key] = key;
+                const retVal = !cache.get(key);
+                cache.set(key, key);
                 return disableDeduplicate || retVal;
               });
               return !!result.nodes.length;
@@ -412,14 +412,4 @@ function reactAxe(
   return checkAndReport(document.body, timeout);
 }
 
-// export function just for tests so we can have a clean state
-// between tests
-export function _reset() {
-  Object.keys(cache).forEach(key => {
-    delete cache[key];
-  });
-
-  axeCore.reset();
-}
-
-export default reactAxe;
+export = reactAxe;

--- a/packages/react/test/index.test.js
+++ b/packages/react/test/index.test.js
@@ -5,7 +5,8 @@ import { mount } from 'enzyme';
 import sinon from 'sinon';
 import { assert } from 'chai';
 import axe from 'axe-core';
-import reactAxe, { _reset } from '../dist/index.js';
+import reactAxe from '../dist/index.js';
+import cache from '../dist/cache.js';
 
 class App extends React.Component {
   constructor(props) {
@@ -62,7 +63,8 @@ describe(`@axe-core/react using react@${React.version}`, () => {
   });
 
   afterEach(() => {
-    _reset();
+    cache.clear();
+    axe.reset();
 
     divWrapper.remove();
     mountedComps.forEach(comp => comp.unmount());


### PR DESCRIPTION
Fixing the accidental breaking change when we switched to use `export default` [instead of `export =`](https://github.com/dequelabs/axe-core-npm/pull/466/files#diff-037b868307272ef21e46ce4e727a16583b5d2ae66ed731296e7fc413b33e8832L415)