### PR TITLE
fix(reporter-earl): fix main export

### DIFF
--- a/packages/reporter-earl/tsconfig.json
+++ b/packages/reporter-earl/tsconfig.json
@@ -12,5 +12,5 @@
     "outDir": "dist",
     "typeRoots": ["node_modules/@types"]
   },
-  "include": ["src", "tests"]
+  "include": ["src"]
 }


### PR DESCRIPTION
Fixes the build so it doesn't add `src` and `test` in the `dist` directory and instead properly adds all src files as a direct child to `dist`. The tests didn't need to be built with TypeScript.