### PR TITLE
fix(puppeteer,playwright): Await page close at end of test

### DIFF
--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -290,8 +290,8 @@ export default class AxeBuilder {
         partialResults,
         options
       })
-      .finally(() => {
-        blankPage.close();
+      .finally(async () => {
+        await blankPage.close();
       });
   }
 }

--- a/packages/puppeteer/src/axePuppeteer.ts
+++ b/packages/puppeteer/src/axePuppeteer.ts
@@ -280,8 +280,8 @@ export class AxePuppeteer {
         partialResults as JSONArray,
         axeOptions as JSONObject
       )
-      .finally(() => {
-        blankPage.close();
+      .finally(async () => {
+        await blankPage.close();
       });
   }
 


### PR DESCRIPTION
Resolves #484

This awaits the page close to resolve the intermittent error at the end of a test suite run mentioned in the linked issue.

The error was observed for Puppeteer, but the same fix is applied here for Playwright in the interest of correctness and consistency.

I'm not aware of any easy way to test for the original error, but all existing tests should be passing.