### PR TITLE
ci: create github release for releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,6 +243,20 @@ jobs:
             --force-publish='*' \
             --yes
 
+  # Create a GitHub release.
+  github_release:
+    docker:
+      - image: cimg/go:1.17.1
+    steps:
+      - checkout
+      - run: go get gopkg.in/aktau/github-release.v0
+      - run:
+          name: Download and run GitHub release script
+          command: |
+            curl https://raw.githubusercontent.com/dequelabs/attest-release-scripts/develop/src/node-github-release.sh -s -o ./node-github-release.sh
+            chmod +x ./node-github-release.sh
+            ./node-github-release.sh
+
 workflows:
   version: 2
   build_and_test:
@@ -314,3 +328,6 @@ workflows:
           filters:
             branches:
               only: master
+      - github_release:
+          requires:
+            - production_release


### PR DESCRIPTION
Our [Changelog](https://github.com/dequelabs/axe-core-npm/blob/develop/CHANGELOG.md) is duplicating items between releases. We had a similar problem in axe-core and we were able to fix it by making sure the repo had the github tags properly set up (standard-release looks at the last github commit that pushed a tag to start the changelog diff process). By creating github releases that tag the commits, we should be able to fix the problem going forward.