### PR TITLE
chore: update puppeteer to v16

### DIFF
--- a/packages/puppeteer/package-lock.json
+++ b/packages/puppeteer/package-lock.json
@@ -23,7 +23,7 @@
         "express": "^4.18.1",
         "mocha": "^10.0.0",
         "nyc": "^15.1.0",
-        "puppeteer": "^15.0.1",
+        "puppeteer": "^16.2.0",
         "sinon": "^14.0.0",
         "source-map-support": "^0.5.21",
         "test-listen": "^1.1.0",
@@ -1483,9 +1483,10 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1001819",
-      "dev": true,
-      "license": "BSD-3-Clause"
+      "version": "0.0.1019158",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1019158.tgz",
+      "integrity": "sha512-wvq+KscQ7/6spEV7czhnZc9RM/woz1AY+/Vpd8/h2HFMwJSdTliu7f/yr1A6vDdJfKICZsShqsYpEQbdhg8AFQ==",
+      "dev": true
     },
     "node_modules/diff": {
       "version": "5.0.0",
@@ -3196,23 +3197,23 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "15.0.1",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-16.2.0.tgz",
+      "integrity": "sha512-7Au6iC98rS6WEAD110V4Bxd0iIbqoFtzz9XzkG1BSofidS1VAJ881E1+GFR7Xn2Yea0hbj8n0ErzRyseMp1Ctg==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1001819",
+        "devtools-protocol": "0.0.1019158",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.1",
-        "pkg-dir": "4.2.0",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
         "rimraf": "3.0.2",
         "tar-fs": "2.1.1",
         "unbzip2-stream": "1.4.3",
-        "ws": "8.8.0"
+        "ws": "8.8.1"
       },
       "engines": {
         "node": ">=14.1.0"
@@ -4005,9 +4006,10 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.8.0",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
+      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -5216,7 +5218,9 @@
       "dev": true
     },
     "devtools-protocol": {
-      "version": "0.0.1001819",
+      "version": "0.0.1019158",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1019158.tgz",
+      "integrity": "sha512-wvq+KscQ7/6spEV7czhnZc9RM/woz1AY+/Vpd8/h2HFMwJSdTliu7f/yr1A6vDdJfKICZsShqsYpEQbdhg8AFQ==",
       "dev": true
     },
     "diff": {
@@ -6442,21 +6446,22 @@
       }
     },
     "puppeteer": {
-      "version": "15.0.1",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-16.2.0.tgz",
+      "integrity": "sha512-7Au6iC98rS6WEAD110V4Bxd0iIbqoFtzz9XzkG1BSofidS1VAJ881E1+GFR7Xn2Yea0hbj8n0ErzRyseMp1Ctg==",
       "dev": true,
       "requires": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1001819",
+        "devtools-protocol": "0.0.1019158",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.1",
-        "pkg-dir": "4.2.0",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
         "rimraf": "3.0.2",
         "tar-fs": "2.1.1",
         "unbzip2-stream": "1.4.3",
-        "ws": "8.8.0"
+        "ws": "8.8.1"
       },
       "dependencies": {
         "debug": {
@@ -7031,7 +7036,9 @@
       }
     },
     "ws": {
-      "version": "8.8.0",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
+      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
       "dev": true,
       "requires": {}
     },

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -34,7 +34,7 @@
     "express": "^4.18.1",
     "mocha": "^10.0.0",
     "nyc": "^15.1.0",
-    "puppeteer": "^15.0.1",
+    "puppeteer": "^16.2.0",
     "sinon": "^14.0.0",
     "source-map-support": "^0.5.21",
     "test-listen": "^1.1.0",
@@ -45,7 +45,7 @@
     "axe-core": "^4.4.2"
   },
   "peerDependencies": {
-    "puppeteer": ">=1.10.0 <= 15"
+    "puppeteer": ">=1.10.0 <= 16"
   },
   "engines": {
     "node": ">=6.4.0"


### PR DESCRIPTION
Hi! I am looking to update puppeteer on my project, but axe-core's peer dep on puppeteer is blocking me. If this could be merged in before https://github.com/dequelabs/axe-core-npm/pull/544 is released, that would be great!