### PR TITLE
ci: update `auto-assign-issues.yml` to target new board

### DIFF
--- a/.github/workflows/auto-assign-issues.yml
+++ b/.github/workflows/auto-assign-issues.yml
@@ -14,5 +14,5 @@ jobs:
       - name: Auto assign axe-core integration issues to Axe API team project board
         uses: srggrs/assign-one-project-github-action@1.2.1
         with:
-          project: https://github.com/orgs/dequelabs/projects/53
+          project: https://github.com/orgs/dequelabs/projects/66
           column_name: 'Ungroomed'


### PR DESCRIPTION
This updates the board to target the new board, found in: 

>No project was found.

https://github.com/dequelabs/axe-core-npm/actions/runs/3230737540/jobs/5289524368#step:3:8

