### PR TITLE
chore(playwright): add named export 

### DIFF
--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -22,7 +22,7 @@ import {
 } from './browser';
 import AxePartialRunner from './AxePartialRunner';
 
-export default class AxeBuilder {
+export class AxeBuilder {
   private page: Page;
   private includes: SerialSelectorList;
   private excludes: SerialSelectorList;
@@ -326,3 +326,5 @@ export default class AxeBuilder {
     `;
   }
 }
+
+export default AxeBuilder;

--- a/packages/playwright/tests/axe-playwright.spec.ts
+++ b/packages/playwright/tests/axe-playwright.spec.ts
@@ -13,6 +13,7 @@ import { assert } from 'chai';
 import path from 'path';
 import { Server, createServer } from 'http';
 import AxeBuilder from '../src';
+import { AxeBuilder as AxeBuilderFromNamed } from '../src';
 
 describe('@axe-core/playwright', () => {
   let server: Server;
@@ -62,6 +63,10 @@ describe('@axe-core/playwright', () => {
   afterEach(async () => {
     await browser.close();
   });
+
+  it('should have a named export that matches the default export', () => {
+    assert.equal(AxeBuilder, AxeBuilderFromNamed)
+  })
 
   describe('analyze', () => {
     it('returns results using a different version of axe-core', async () => {


### PR DESCRIPTION
https://github.com/dequelabs/axe-core-npm/issues/660

Added a named export while leaving the default export intact. This allows code that was previously using playwright to continue to do so, but allow new code to use named exports regardless of whether it is using `require` or `import` style imports.

The following .mjs file properly imports playwright:

```javascript
// test.mjs
import { AxeBuilder } from '@axe-core/playwright';
console.log(AxeBuilder);
```