### PR TITLE
feat(webdriverio): deprecate @wdio/sync support

### DIFF
--- a/packages/webdriverio/README.md
+++ b/packages/webdriverio/README.md
@@ -2,6 +2,10 @@
 
 > Provides a chainable axe API for WebdriverIO and automatically injects into all frames.
 
+## Feature Deprecation Notice
+
+Support for `@wdio/sync` is deprecated and testing for it will be removed in a future release.
+
 ## Getting Started
 
 Install [Node.js](https://docs.npmjs.com/getting-started/installing-node) if you haven't already.


### PR DESCRIPTION
https://github.com/dequelabs/axe-core-npm/issues/674

Not much to really be done here other than the readme message. The package itself is only used in tests, but can't be removed until we actually remove support.