### PR TITLE
fix(cli): increase --timeout default to 90 seconds (to match --help)

### DIFF
--- a/packages/cli/.eslintrc.js
+++ b/packages/cli/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   rules: {
     '@typescript-eslint/no-empty-function': 'off',
-    '@typescript-eslint/ban-ts-ignore': 'off',
+    '@typescript-eslint/ban-ts-comment': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off'
   },
   overrides: [

--- a/packages/cli/src/bin/cli.ts
+++ b/packages/cli/src/bin/cli.ts
@@ -60,7 +60,9 @@ program
   )
   .option(
     '--timeout <n>',
-    'Set how much time (seconds) axe has to run (default: 90)'
+    'Set how much time (seconds) axe has to run',
+    // @ts-ignore
+    90
   )
   .option('--timer', 'Log the time it takes to run')
   .option('--show-errors [boolean]', 'Display the full error stack', true)

--- a/packages/cli/src/lib/webdriver.test.ts
+++ b/packages/cli/src/lib/webdriver.test.ts
@@ -14,6 +14,7 @@ describe('startDriver', () => {
   beforeEach(() => {
     browser = 'chrome-headless';
     config = {
+      timeout: 90,
       get browser() {
         return browser;
       }

--- a/packages/cli/src/lib/webdriver.ts
+++ b/packages/cli/src/lib/webdriver.ts
@@ -6,7 +6,7 @@ import { WebdriverConfigParams } from '../types';
 const startDriver = async (
   config: WebdriverConfigParams
 ): Promise<WebDriver> => {
-  const scriptTimeout = (config.timeout || 20) * 1000.0;
+  const scriptTimeout = config.timeout * 1000.0;
   let builder: Builder;
   /* istanbul ignore else */
   if (config.browser === 'chrome-headless') {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -21,7 +21,7 @@ export interface EventResponse {
 
 export interface WebdriverConfigParams {
   browser: string;
-  timeout?: number;
+  timeout: number;
   chromedriverPath?: string;
   path?: string;
   chromeOptions?: string[];


### PR DESCRIPTION
The timeout was decreased in 6f5498ee8a2acb78846aa623773c7d1de19125e0 to 20 seconds (apparently accidentally since that commit was classfied as a refactor ... and it also didn't update the --help text accordingly).

This commit changes it back to 90 seconds to match the --help text.