### PR TITLE
ci: fix webdriverio test using wrong chromedriver (#684

### DIFF
--- a/packages/webdriverio/src/test.ts
+++ b/packages/webdriverio/src/test.ts
@@ -13,6 +13,8 @@ import AxeBuilder from '.';
 import { logOrRethrowError } from './utils';
 import { WdioBrowser } from './types';
 import type { AxeResults, Result } from 'axe-core';
+import child_process from 'child_process';
+import { ChildProcessWithoutNullStreams } from 'child_process';
 
 const connectToChromeDriver = (port: number): Promise<void> => {
   let socket: net.Socket;
@@ -50,14 +52,20 @@ describe('@axe-core/webdriverio', () => {
   for (const protocol of ['devtools', 'webdriver'] as const) {
     if (protocol === 'webdriver') {
       port = 9515;
+
+      let chromedriverProcess: ChildProcessWithoutNullStreams;
+
       before(async () => {
-        chromedriver.start([`--port=${port}`]);
+        const path = process.env.CI ? '/usr/local/bin/chromedriver' : chromedriver.path;
+        chromedriverProcess = child_process.spawn(path, [`--port=${port}`]);
+        chromedriverProcess.stdout.pipe(process.stdout);
+        chromedriverProcess.stderr.pipe(process.stderr);
         await delay(500);
         await connectToChromeDriver(port);
       });
 
       after(() => {
-        chromedriver.stop();
+        chromedriverProcess.kill();
       });
     }
 


### PR DESCRIPTION
The webdriverio CI job was failing with the error message:

    session not created: This version of ChromeDriver only supports Chrome version 109
    Current browser version is 111.0.5563.64 with binary path /usr/bin/google-chrome

Despite the job running the following steps:

    - browser-tools/install-chrome
    - browser-tools/install-chromedriver
    - run: npm run coverage --prefix=packages/webdriverio

And browser-tools/install-chromedriver automatically installing the right version of chromedriver based on the previously installed chrome version.[1]

This was because browser-tools/install-chromedriver installed the chromedriver under /usr/local/bin/chromedriver while packages/webdriverio/src/test.ts was using the chromedriver from the chromedriver NPM package (which is currently set to ^109.0.0 in package.json).

This commit changes the webdriverio test code to instead use the system-wide installed chromedriver (that has been installed via browser-tools/install-chromedriver) in a CI environment.

[1]: https://circleci.com/developer/orbs/orb/circleci/browser-tools#commands-install-chromedriver