### PR TITLE
refactor: make tests respect CHROMEDRIVER_PATH

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,11 +155,13 @@ jobs:
     steps:
       - checkout
       - restore_dependency_cache
-      # required for browser-driver-manager
-      - run: sudo apt-get update -y
-      - run: cd packages/webdriverjs && npx browser-driver-manager@1.0.4 install chrome chromedriver --verbose
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - run: npm --prefix=packages/webdriverjs run build
-      - run: npm run coverage --prefix=packages/webdriverjs
+      - run:
+          command: npm run coverage --prefix=packages/webdriverjs
+          environment:
+            CHROMEDRIVER_PATH: /usr/local/bin/chromedriver
 
   webdriverjs-example:
     <<: *defaults
@@ -169,7 +171,10 @@ jobs:
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
       - run: npm --prefix=packages/webdriverjs run build
-      - run: npm run test --prefix=packages/webdriverjs/tests/example
+      - run:
+          command: npm run test --prefix=packages/webdriverjs/tests/example
+          environment:
+            CHROMEDRIVER_PATH: /usr/local/bin/chromedriver
 
   webdriverio:
     docker:
@@ -182,7 +187,10 @@ jobs:
       - restore_dependency_cache
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
-      - run: npm run coverage --prefix=packages/webdriverio
+      - run:
+          command: npm run coverage --prefix=packages/webdriverio
+          environment:
+            CHROMEDRIVER_PATH: /usr/local/bin/chromedriver
 
   reporter-earl:
     <<: *defaults

--- a/packages/webdriverio/src/test.ts
+++ b/packages/webdriverio/src/test.ts
@@ -56,7 +56,7 @@ describe('@axe-core/webdriverio', () => {
       let chromedriverProcess: ChildProcessWithoutNullStreams;
 
       before(async () => {
-        const path = process.env.CI ? '/usr/local/bin/chromedriver' : chromedriver.path;
+        const path = process.env.CHROMEDRIVER_PATH ?? chromedriver.path;
         chromedriverProcess = child_process.spawn(path, [`--port=${port}`]);
         chromedriverProcess.stdout.pipe(process.stdout);
         chromedriverProcess.stderr.pipe(process.stderr);

--- a/packages/webdriverjs/tests/example/webdriverjs-example.ts
+++ b/packages/webdriverjs/tests/example/webdriverjs-example.ts
@@ -20,10 +20,17 @@ describe('@axe-core/webdriverjs example', () => {
   });
 
   beforeEach(async () => {
-    driver = new Builder()
+    const builder = new Builder()
       .forBrowser('chrome')
-      .setChromeOptions(new chrome.Options().headless())
-      .build();
+      .setChromeOptions(new chrome.Options().headless());
+
+    if (process.env.CHROMEDRIVER_PATH) {
+      builder.setChromeService(
+        new chrome.ServiceBuilder(process.env.CHROMEDRIVER_PATH)
+      );
+    }
+
+    driver = builder.build();
   });
 
   afterEach(() => {

--- a/packages/webdriverjs/tests/test-utils.ts
+++ b/packages/webdriverjs/tests/test-utils.ts
@@ -14,6 +14,11 @@ export const Webdriver = (): WebDriver => {
       .setChromeOptions(new chrome.Options().headless())
       .forBrowser('chrome');
   }
+  if (process.env.CHROMEDRIVER_PATH) {
+    builder.setChromeService(
+      new chrome.ServiceBuilder(process.env.CHROMEDRIVER_PATH)
+    );
+  }
   return builder.build();
 };
 

--- a/packages/webdriverjs/tests/test-utils.ts
+++ b/packages/webdriverjs/tests/test-utils.ts
@@ -3,20 +3,18 @@ import net from 'net';
 import chrome from 'selenium-webdriver/chrome';
 
 export const Webdriver = (): WebDriver => {
-  let webdriver: WebDriver;
+  let builder: Builder;
   if (process.env.REMOTE_SELENIUM_URL) {
-    webdriver = new Builder()
+    builder = new Builder()
       .forBrowser('chrome')
       .usingServer(process.env.REMOTE_SELENIUM_URL)
-      .setChromeOptions(new chrome.Options().headless())
-      .build();
+      .setChromeOptions(new chrome.Options().headless());
   } else {
-    webdriver = new Builder()
+    builder = new Builder()
       .setChromeOptions(new chrome.Options().headless())
-      .forBrowser('chrome')
-      .build();
+      .forBrowser('chrome');
   }
-  return webdriver;
+  return builder.build();
 };
 
 export const connectToChromeDriver = (port: number): Promise<void> => {


### PR DESCRIPTION
This change helps prevent chromedriver version mismatches in the CI
by no longer requiring the chromedriver version in `package-lock.json`
to match the chrome version installed in the CI.

I already previously added similar logic in 3a38cf751636aa9846c77c580e21bb903b7185f6
for webdriverio. This commit improves that logic to no longer hard-code the chromedriver
path in the test and instead provide it via an environment variable (so it can also be used
to run the tests locally against a Chrome version different than the locked chromedriver version).
This commit additionally adapts webdriverjs and webdriverjs-example to also respect
this new CHROMEDRIVER_PATH environment variable.