### PR TITLE
fix(react): include .mjs file in publish

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -20,6 +20,7 @@
     "dist/cache.d.ts",
     "dist/cache.js.map",
     "dist/index.js",
+    "dist/index.mjs",
     "dist/index.d.ts",
     "dist/index.js.map"
   ],


### PR DESCRIPTION
Closes: https://github.com/dequelabs/axe-core-npm/issues/719
Closes: https://github.com/dequelabs/axe-core-npm/issues/721

Testing for every project was done on the `.mjs` files themselves, so this was missed because it solely is about publishing.
There was some testing with the packaged tarball, but that was to ensure that the `exports` field of package.json was correct, not that the new files were exported, so it wasn't done on all packages.

Also, most of our stuff package the entire `dist` directory, so it was missed that `@axe-core/react` exports individual files.