### PR TITLE
ci: remove tests from the `develop` and `master` branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,14 +308,6 @@ workflows:
           context: html-tools
           requires:
             - dependencies
-            - lint
-            - cli
-            - puppeteer
-            - webdriverjs
-            - webdriverio
-            - reporter-earl
-            - react
-            - playwright
           filters:
             branches:
               only:
@@ -324,14 +316,6 @@ workflows:
           context: html-tools
           requires:
             - dependencies
-            - lint
-            - cli
-            - puppeteer
-            - webdriverjs
-            - webdriverio
-            - reporter-earl
-            - react
-            - playwright
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -315,6 +315,7 @@ workflows:
             - webdriverio
             - reporter-earl
             - react
+            - playwright
           filters:
             branches:
               only:
@@ -330,6 +331,7 @@ workflows:
             - webdriverio
             - reporter-earl
             - react
+            - playwright
           filters:
             branches:
               only: master


### PR DESCRIPTION
I noticed we do not depend on the CircleCI playwright job for canary / prod releases. if it fails, we will still publish.

<img width="1570" alt="image" src="https://github.com/dequelabs/axe-core-npm/assets/41127686/20f7026b-a0f8-4c14-8b02-fdb8c0754538">


We don't need to run tests again on the develop and master branch as we run tests on each PR

Closes: https://github.com/dequelabs/axe-core-npm/issues/739