### PR TITLE
chore: Make existing ESLint warnings fail the build

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,10 @@ module.exports = {
     '@typescript-eslint/camelcase': 'off',
     '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
-    '@typescript-eslint/ban-types': 'off'
+    '@typescript-eslint/ban-types': 'off',
+    '@typescript-eslint/no-unused-vars': 'error',
+    '@typescript-eslint/no-explicit-any': 'error',
+    '@typescript-eslint/no-non-null-assertion': 'error'
   },
   settings: {
     react: {
@@ -31,6 +34,13 @@ module.exports = {
       rules: {
         '@typescript-eslint/explicit-function-return-type': 'off',
         '@typescript-eslint/no-var-requires': 'off'
+      }
+    },
+    {
+      files: ['*.test.ts', '*.test.tsx', '*.spec.ts', '*.spec.tsx'],
+      rules: {
+        '@typescript-eslint/no-explicit-any': 'off',
+        '@typescript-eslint/no-non-null-assertion': 'off'
       }
     }
   ]

--- a/packages/cli/src/lib/events.ts
+++ b/packages/cli/src/lib/events.ts
@@ -2,13 +2,7 @@ import type { AxeResults } from 'axe-core';
 import type { EventParams } from '../types';
 import { selectorToString, error, link, bold, green } from './utils';
 
-export default ({
-  silentMode,
-  timer,
-  cliReporter,
-  verbose,
-  exit
-}: EventParams) => {
+export default ({ silentMode, timer, cliReporter, verbose }: EventParams) => {
   return {
     startTimer: (message: string) => {
       console.time(message);

--- a/packages/cli/src/lib/webdriver.ts
+++ b/packages/cli/src/lib/webdriver.ts
@@ -1,5 +1,5 @@
 import chromedriver from 'chromedriver';
-import { Builder, Capabilities, WebDriver } from 'selenium-webdriver';
+import { Builder, type WebDriver } from 'selenium-webdriver';
 import chrome from 'selenium-webdriver/chrome';
 import { WebdriverConfigParams } from '../types';
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -6,7 +6,7 @@ export * from './lib';
 export interface EventParams {
   silentMode: boolean;
   timer: boolean;
-  cliReporter: (...args: any[]) => void;
+  cliReporter: (...args: unknown[]) => void;
   verbose: boolean;
   exit: boolean;
 }

--- a/packages/puppeteer/src/browser.ts
+++ b/packages/puppeteer/src/browser.ts
@@ -1,6 +1,5 @@
 // This module encapsulates the browser environment
 import * as Axe from 'axe-core';
-import { PartialResults } from './types';
 
 // Expect axe to be set up.
 // Tell Typescript that there should be a global variable called `axe` that follows

--- a/packages/reporter-earl/src/types.ts
+++ b/packages/reporter-earl/src/types.ts
@@ -12,12 +12,6 @@ export interface EarlResult {
   assertions: Assertion[];
 }
 
-type outcome =
-  | 'earl:inapplicable'
-  | 'earl:passed'
-  | 'earl:incomplete'
-  | 'earl:failed';
-
 export interface Assertion {
   '@type': EarlType.Assertion;
   mode: 'earl:automatic';

--- a/packages/webdriverio/src/index.ts
+++ b/packages/webdriverio/src/index.ts
@@ -31,6 +31,7 @@ async function loadAxePath() {
   if (typeof require === 'function' && typeof require.resolve === 'function') {
     axeCorePath = require.resolve('axe-core');
   } else {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { createRequire } = (await import('node:module')) as any;
     // `getFilename` is needed because esm's `import.meta.url` is illegal syntax in cjs
     const filename = pathToFileURL(getFilename()).toString();
@@ -246,15 +247,15 @@ export default class AxeBuilder {
     // the default length of 30 seconds)
     const { pageLoad } = await this.client.getTimeouts();
     this.client.setTimeout({
-      pageLoad: FRAME_LOAD_TIMEOUT,
+      pageLoad: FRAME_LOAD_TIMEOUT
     });
 
-    let partials: PartialResults | null
+    let partials: PartialResults | null;
     try {
       partials = await this.runPartialRecursive(context);
     } finally {
       this.client.setTimeout({
-        pageLoad,
+        pageLoad
       });
     }
 
@@ -329,10 +330,15 @@ export default class AxeBuilder {
         assert(frame, `Expect frame of "${frameSelector}" to be defined`);
         await this.client.switchToFrame(frame);
         await axeSourceInject(this.client, this.script);
-        partials.push(...(await this.runPartialRecursive(frameContext, [...frameStack, frame])));
+        partials.push(
+          ...(await this.runPartialRecursive(frameContext, [
+            ...frameStack,
+            frame
+          ]))
+        );
       } catch (error) {
-        const [topWindow] = await this.client.getWindowHandles()
-        await this.client.switchToWindow(topWindow)
+        const [topWindow] = await this.client.getWindowHandles();
+        await this.client.switchToWindow(topWindow);
 
         for (const frameElm of frameStack) {
           await this.client.switchToFrame(frameElm);
@@ -374,4 +380,4 @@ export default class AxeBuilder {
   }
 }
 
-export { AxeBuilder }
+export { AxeBuilder };

--- a/packages/webdriverio/src/utils.ts
+++ b/packages/webdriverio/src/utils.ts
@@ -10,7 +10,7 @@ import type {
   SerialContextObject
 } from 'axe-core';
 
-export const FRAME_LOAD_TIMEOUT = 1000
+export const FRAME_LOAD_TIMEOUT = 1000;
 
 /**
  * Validates that the client provided is WebdriverIO v5 or v6.
@@ -117,10 +117,10 @@ async function assertFrameReady(client: Browser): Promise<void> {
     const timeoutPromise = new Promise((resolve, reject) => {
       setTimeout(() => {
         reject();
-      }, FRAME_LOAD_TIMEOUT)
+      }, FRAME_LOAD_TIMEOUT);
     });
     const executePromise = client.execute(() => {
-      return document.readyState === 'complete'
+      return document.readyState === 'complete';
     });
     const readyState = await Promise.race([timeoutPromise, executePromise]);
     assert(readyState);
@@ -136,7 +136,7 @@ export const axeRunPartial = (
 ): Promise<PartialResult> => {
   return promisify(
     client
-      .executeAsync<string, never>(
+      .executeAsync<string, []>(
         `
       var callback = arguments[arguments.length - 1];
       var context = ${JSON.stringify(context)} || document;
@@ -152,6 +152,8 @@ export const axeRunPartial = (
 export const axeGetFrameContext = (
   client: Browser,
   context: SerialContextObject
+  // TODO: add proper types
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<any[]> => {
   return promisify(
     // Had to use executeAsync() because we could not use multiline statements in client.execute()
@@ -173,7 +175,7 @@ export const axeRunLegacy = (
 ): Promise<AxeResults> => {
   return promisify(
     client
-      .executeAsync<string, never>(
+      .executeAsync<string, []>(
         `var callback = arguments[arguments.length - 1];
       var context = ${JSON.stringify(context)} || document;
       var options = ${JSON.stringify(options)} || {};
@@ -221,7 +223,7 @@ export const axeFinishRun = (
   return chunkResults(partialString)
     .then(() => {
       return promisify(
-        client.executeAsync<string, never>(
+        client.executeAsync<string, []>(
           `var callback = arguments[arguments.length - 1];
       ${axeSource};
       window.axe.configure({

--- a/packages/webdriverio/test/axe-webdriverio.spec.ts
+++ b/packages/webdriverio/test/axe-webdriverio.spec.ts
@@ -855,14 +855,17 @@ describe('@axe-core/webdriverio', () => {
             await client.url(`${addr}/lazy-loaded-iframe.html`);
             const title = await client.getTitle();
 
-            const results = await new AxeBuilder({client})
+            const results = await new AxeBuilder({ client })
               .options({ runOnly: ['label', 'frame-tested'] })
               .analyze();
 
             assert.notEqual(title, 'Error');
             assert.equal(results.incomplete[0].id, 'frame-tested');
             assert.lengthOf(results.incomplete[0].nodes, 1);
-            assert.deepEqual(results.incomplete[0].nodes[0].target, ['#ifr-lazy', '#lazy-iframe']);
+            assert.deepEqual(results.incomplete[0].nodes[0].target, [
+              '#ifr-lazy',
+              '#lazy-iframe'
+            ]);
             assert.equal(results.violations[0].id, 'label');
             assert.lengthOf(results.violations[0].nodes, 1);
             assert.deepEqual(results.violations[0].nodes[0].target, [
@@ -874,10 +877,10 @@ describe('@axe-core/webdriverio', () => {
 
           it('resets pageLoad timeout to user setting', async () => {
             await client.url(`${addr}/lazy-loaded-iframe.html`);
-            client.setTimeout({ pageLoad: 500 })
-            const title = await client.getTitle();
+            client.setTimeout({ pageLoad: 500 });
+            await client.getTitle();
 
-            const results = await new AxeBuilder({client})
+            await new AxeBuilder({ client })
               .options({ runOnly: ['label', 'frame-tested'] })
               .analyze();
 
@@ -1461,7 +1464,7 @@ describe('@axe-core/webdriverio', () => {
 
         it('should not set when running runPartial and not legacy mode', async () => {
           await client.url(`${addr}/index.html`);
-          const res = await new AxeBuilder({ client }).analyze();
+          await new AxeBuilder({ client }).analyze();
           const allowedOrigins = await getAllowedOrigins();
           assert.deepEqual(allowedOrigins, [addr]);
         });
@@ -1484,7 +1487,7 @@ describe('@axe-core/webdriverio', () => {
 
         it('should set when running legacy source and not legacy mode', async () => {
           await client.url(`${addr}/index.html`);
-          const res = await new AxeBuilder({
+          await new AxeBuilder({
             client,
             axeSource: axeLegacySource
           }).analyze();

--- a/packages/webdriverjs/src/browser.ts
+++ b/packages/webdriverjs/src/browser.ts
@@ -3,8 +3,7 @@ import {
   SerialContextObject,
   FrameContext,
   RunOptions,
-  Spec,
-  PartialResult
+  Spec
 } from 'axe-core';
 import { WebDriver, WebElement } from 'selenium-webdriver';
 

--- a/packages/webdriverjs/src/index.ts
+++ b/packages/webdriverjs/src/index.ts
@@ -8,7 +8,7 @@ import axe, {
   SerialFrameSelector
 } from 'axe-core';
 const { source } = axe;
-import { CallbackFunction, BuilderOptions, Selector } from './types';
+import { CallbackFunction, BuilderOptions } from './types';
 import { normalizeContext } from './utils/index';
 import AxeInjector from './axe-injector';
 import {
@@ -179,7 +179,7 @@ export default class AxeBuilder {
     const { pageLoad } = await this.driver.manage().getTimeouts();
     this.driver.manage().setTimeouts({ pageLoad: 1000 });
 
-    let partials: string[]
+    let partials: string[];
     try {
       partials = await this.runPartialRecursive(context);
     } finally {
@@ -237,7 +237,12 @@ export default class AxeBuilder {
       try {
         assert(frame, `Expect frame of "${frameSelector}" to be defined`);
         await this.driver.switchTo().frame(frame);
-        partials.push(...(await this.runPartialRecursive(frameContext, [...frameStack, frame])));
+        partials.push(
+          ...(await this.runPartialRecursive(frameContext, [
+            ...frameStack,
+            frame
+          ]))
+        );
         await this.driver.switchTo().parentFrame();
       } catch {
         /*
@@ -286,4 +291,4 @@ export default class AxeBuilder {
   }
 }
 
-export { AxeBuilder }
+export { AxeBuilder };

--- a/packages/webdriverjs/src/utils/index.ts
+++ b/packages/webdriverjs/src/utils/index.ts
@@ -1,5 +1,4 @@
 import type { SerialContextObject, SerialSelectorList } from 'axe-core';
-import { Selector } from '../types';
 
 /**
  * Get running context

--- a/packages/webdriverjs/test/axe-webdriverjs.spec.ts
+++ b/packages/webdriverjs/test/axe-webdriverjs.spec.ts
@@ -393,7 +393,10 @@ describe('@axe-core/webdriverjs', () => {
       assert.notEqual(title, 'Error');
       assert.equal(results.incomplete[0].id, 'frame-tested');
       assert.lengthOf(results.incomplete[0].nodes, 1);
-      assert.deepEqual(results.incomplete[0].nodes[0].target, ['#ifr-lazy', '#lazy-iframe']);
+      assert.deepEqual(results.incomplete[0].nodes[0].target, [
+        '#ifr-lazy',
+        '#lazy-iframe'
+      ]);
       assert.equal(results.violations[0].id, 'label');
       assert.lengthOf(results.violations[0].nodes, 1);
       assert.deepEqual(results.violations[0].nodes[0].target, [
@@ -401,20 +404,20 @@ describe('@axe-core/webdriverjs', () => {
         '#lazy-baz',
         'input'
       ]);
-    })
+    });
 
     it('resets pageLoad timeout to user setting', async () => {
       await driver.get(`${addr}/external/lazy-loaded-iframe.html`);
-      driver.manage().setTimeouts({ pageLoad: 500 })
-      const title = await driver.getTitle();
+      driver.manage().setTimeouts({ pageLoad: 500 });
+      await driver.getTitle();
 
-      const results = await new AxeBuilder(driver)
+      await new AxeBuilder(driver)
         .options({ runOnly: ['label', 'frame-tested'] })
         .analyze();
 
       const timeout = await driver.manage().getTimeouts();
       assert.equal(timeout.pageLoad, 500);
-    })
+    });
   });
 
   describe('withRules', () => {


### PR DESCRIPTION
People don't care about warnings. Unless a build fails, ESLint output will go unnoticed. This patch prevents that from happening by converting existing warnings to errors.

Also all existing warnings have been fixed.