### PR TITLE
ci: add default timeout to test suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,10 @@ on:
       - "!master" # except master
       - "!develop" # except develop
 
+env:
+  # Point tests to run from newest stable chromedriver
+  CHROMEDRIVER_PATH: /usr/local/bin/chromedriver
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,20 +1,11 @@
 name: Tests
 
-on:
-  push:
-    branches:
-      - "**" # all branches
-      - "!master" # except master
-      - "!develop" # except develop
-
-env:
-  # Point tests to run from newest stable chromedriver
-  CHROMEDRIVER_PATH: /usr/local/bin/chromedriver
+on: [push]
 
 jobs:
   lint:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -30,6 +21,7 @@ jobs:
       matrix:
         node: [16, 18, 20]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: lint
     steps:
       - uses: actions/checkout@v3
@@ -51,6 +43,7 @@ jobs:
       matrix:
         node: [16, 18, 20]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: lint
     steps:
       - uses: actions/checkout@v3
@@ -75,6 +68,7 @@ jobs:
       matrix:
         node: [16, 18, 20]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: lint
     steps:
       - uses: actions/checkout@v3
@@ -96,6 +90,7 @@ jobs:
       matrix:
         node: [16, 18, 20]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: lint
     steps:
       - uses: actions/checkout@v3
@@ -117,6 +112,7 @@ jobs:
       matrix:
         node: [16, 18, 20]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: lint
     steps:
       - uses: actions/checkout@v3
@@ -135,6 +131,7 @@ jobs:
       matrix:
         node: [16, 18, 20]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: lint
     steps:
       - uses: actions/checkout@v3
@@ -153,6 +150,7 @@ jobs:
       matrix:
         node: [16, 18, 20]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: lint
     steps:
       - uses: actions/checkout@v3
@@ -170,6 +168,7 @@ jobs:
   axe_core_test:
     if: github.ref_name == 'master' || startsWith(github.ref_name, 'release')
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: lint
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on: [push]
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,10 @@
 name: Tests
 
-on: [push]
+on: push:
+    branches:
+      - "**" # all branches
+      - "!master" # except master
+      - "!develop" # except develop
 
 jobs:
   lint:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,7 @@
 name: Tests
 
-on: push:
+on:
+  push:
     branches:
       - "**" # all branches
       - "!master" # except master

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@axe-core/webdriverjs": "^4.7.3",
         "axe-core": "^4.7.0",
-        "chromedriver": "^113.0.0",
+        "chromedriver": "^115.0.1",
         "colors": "^1.4.0",
         "commander": "^9.4.1",
         "selenium-webdriver": "^4.8.1"
@@ -53,9 +53,9 @@
       }
     },
     "node_modules/@axe-core/webdriverjs": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@axe-core/webdriverjs/-/webdriverjs-4.7.1.tgz",
-      "integrity": "sha512-Cf3gFDKYkMDo1vO9QQ3uIRP/iyiacxbu6YWFl0LqKG3u4AtUeR64xZ5weexr5xAKixu/sDQmcpjLskkgO9QK9w==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/webdriverjs/-/webdriverjs-4.7.3.tgz",
+      "integrity": "sha512-9mSQmk5jSxZcuwLRLQfDymZ/a3xYH8R1aH9V9wM015zhrA3BjS5TF8FNQOY0iErBmUOgFg+cH30fIek5UMVnNw==",
       "dependencies": {
         "axe-core": "^4.7.0"
       },
@@ -889,9 +889,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.1.tgz",
-      "integrity": "sha512-I88cFiGu9ryt/tfVEi4kX2SITsvDddTajXTOFmt2uK1ZVA8LytjtdeyefdQWEf5PU8w+4SSJDoYnggflB5tW4A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -1101,14 +1101,14 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "113.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-113.0.0.tgz",
-      "integrity": "sha512-UnQlt2kPicYXVNHPzy9HfcWvEbKJjjKAEaatdcnP/lCIRwuSoZFVLH0HVDAGdbraXp3dNVhfE2Qx7gw8TnHnPw==",
+      "version": "115.0.1",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-115.0.1.tgz",
+      "integrity": "sha512-faE6WvIhXfhnoZ3nAxUXYzeDCKy612oPwpkUp0mVkA7fZPg2JHSUiYOQhUYgzHQgGvDWD5Fy2+M2xV55GKHBVQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@testim/chrome-version": "^1.1.3",
-        "axios": "^1.2.1",
-        "compare-versions": "^5.0.1",
+        "axios": "^1.4.0",
+        "compare-versions": "^6.0.0",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^1.1.0",
@@ -1193,9 +1193,9 @@
       "dev": true
     },
     "node_modules/compare-versions": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-5.0.2.tgz",
-      "integrity": "sha512-9fSIz5PC8Re0YhgwBi1QXq92NnxhuSjTfWB0elKEtjTGIUYDeZC44cusX1BvHTwnyG+HBQRCmJ3F1qx18z/D7w=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.0.tgz",
+      "integrity": "sha512-LNZQXhqUvqUTotpZ00qLSaify3b4VFD588aRr8MKFw4CMUr98ytzCW5wDH5qx/DEY5kCDXcbcRuCqL0szEf2tg=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -3714,9 +3714,9 @@
       }
     },
     "@axe-core/webdriverjs": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@axe-core/webdriverjs/-/webdriverjs-4.7.1.tgz",
-      "integrity": "sha512-Cf3gFDKYkMDo1vO9QQ3uIRP/iyiacxbu6YWFl0LqKG3u4AtUeR64xZ5weexr5xAKixu/sDQmcpjLskkgO9QK9w==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/webdriverjs/-/webdriverjs-4.7.3.tgz",
+      "integrity": "sha512-9mSQmk5jSxZcuwLRLQfDymZ/a3xYH8R1aH9V9wM015zhrA3BjS5TF8FNQOY0iErBmUOgFg+cH30fIek5UMVnNw==",
       "requires": {
         "axe-core": "^4.7.0"
       }
@@ -4377,9 +4377,9 @@
       "integrity": "sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ=="
     },
     "axios": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.1.tgz",
-      "integrity": "sha512-I88cFiGu9ryt/tfVEi4kX2SITsvDddTajXTOFmt2uK1ZVA8LytjtdeyefdQWEf5PU8w+4SSJDoYnggflB5tW4A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -4521,13 +4521,13 @@
       }
     },
     "chromedriver": {
-      "version": "113.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-113.0.0.tgz",
-      "integrity": "sha512-UnQlt2kPicYXVNHPzy9HfcWvEbKJjjKAEaatdcnP/lCIRwuSoZFVLH0HVDAGdbraXp3dNVhfE2Qx7gw8TnHnPw==",
+      "version": "115.0.1",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-115.0.1.tgz",
+      "integrity": "sha512-faE6WvIhXfhnoZ3nAxUXYzeDCKy612oPwpkUp0mVkA7fZPg2JHSUiYOQhUYgzHQgGvDWD5Fy2+M2xV55GKHBVQ==",
       "requires": {
         "@testim/chrome-version": "^1.1.3",
-        "axios": "^1.2.1",
-        "compare-versions": "^5.0.1",
+        "axios": "^1.4.0",
+        "compare-versions": "^6.0.0",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^1.1.0",
@@ -4591,9 +4591,9 @@
       "dev": true
     },
     "compare-versions": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-5.0.2.tgz",
-      "integrity": "sha512-9fSIz5PC8Re0YhgwBi1QXq92NnxhuSjTfWB0elKEtjTGIUYDeZC44cusX1BvHTwnyG+HBQRCmJ3F1qx18z/D7w=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.0.tgz",
+      "integrity": "sha512-LNZQXhqUvqUTotpZ00qLSaify3b4VFD588aRr8MKFw4CMUr98ytzCW5wDH5qx/DEY5kCDXcbcRuCqL0szEf2tg=="
     },
     "concat-map": {
       "version": "0.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@axe-core/webdriverjs": "^4.7.3",
     "axe-core": "^4.7.0",
-    "chromedriver": "^113.0.0",
+    "chromedriver": "^115.0.1",
     "colors": "^1.4.0",
     "commander": "^9.4.1",
     "selenium-webdriver": "^4.8.1"

--- a/packages/webdriverio/package-lock.json
+++ b/packages/webdriverio/package-lock.json
@@ -22,7 +22,7 @@
         "@types/test-listen": "^1.1.0",
         "axe-test-fixtures": "github:dequelabs/axe-test-fixtures#v1",
         "chai": "^4.3.6",
-        "chromedriver": "^113.0.0",
+        "chromedriver": "^115.0.1",
         "cross-dirname": "^0.1.0",
         "delay": "^5.0.0",
         "express": "^4.18.2",
@@ -1712,9 +1712,9 @@
       "license": "MPL-2.0"
     },
     "node_modules/axios": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.1.tgz",
-      "integrity": "sha512-I88cFiGu9ryt/tfVEi4kX2SITsvDddTajXTOFmt2uK1ZVA8LytjtdeyefdQWEf5PU8w+4SSJDoYnggflB5tW4A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
       "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.0",
@@ -2111,15 +2111,15 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "113.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-113.0.0.tgz",
-      "integrity": "sha512-UnQlt2kPicYXVNHPzy9HfcWvEbKJjjKAEaatdcnP/lCIRwuSoZFVLH0HVDAGdbraXp3dNVhfE2Qx7gw8TnHnPw==",
+      "version": "115.0.1",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-115.0.1.tgz",
+      "integrity": "sha512-faE6WvIhXfhnoZ3nAxUXYzeDCKy612oPwpkUp0mVkA7fZPg2JHSUiYOQhUYgzHQgGvDWD5Fy2+M2xV55GKHBVQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@testim/chrome-version": "^1.1.3",
-        "axios": "^1.2.1",
-        "compare-versions": "^5.0.1",
+        "axios": "^1.4.0",
+        "compare-versions": "^6.0.0",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^1.1.0",
@@ -2210,9 +2210,9 @@
       "dev": true
     },
     "node_modules/compare-versions": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-5.0.1.tgz",
-      "integrity": "sha512-v8Au3l0b+Nwkp4G142JcgJFh1/TUhdxut7wzD1Nq1dyp5oa3tXaqb03EXOAB6jS4gMlalkjAUPZBMiAfKUixHQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.0.tgz",
+      "integrity": "sha512-LNZQXhqUvqUTotpZ00qLSaify3b4VFD588aRr8MKFw4CMUr98ytzCW5wDH5qx/DEY5kCDXcbcRuCqL0szEf2tg==",
       "dev": true
     },
     "node_modules/compress-commons": {
@@ -8053,9 +8053,9 @@
       "from": "axe-test-fixtures@github:dequelabs/axe-test-fixtures#v1"
     },
     "axios": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.1.tgz",
-      "integrity": "sha512-I88cFiGu9ryt/tfVEi4kX2SITsvDddTajXTOFmt2uK1ZVA8LytjtdeyefdQWEf5PU8w+4SSJDoYnggflB5tW4A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
       "dev": true,
       "requires": {
         "follow-redirects": "^1.15.0",
@@ -8322,14 +8322,14 @@
       }
     },
     "chromedriver": {
-      "version": "113.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-113.0.0.tgz",
-      "integrity": "sha512-UnQlt2kPicYXVNHPzy9HfcWvEbKJjjKAEaatdcnP/lCIRwuSoZFVLH0HVDAGdbraXp3dNVhfE2Qx7gw8TnHnPw==",
+      "version": "115.0.1",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-115.0.1.tgz",
+      "integrity": "sha512-faE6WvIhXfhnoZ3nAxUXYzeDCKy612oPwpkUp0mVkA7fZPg2JHSUiYOQhUYgzHQgGvDWD5Fy2+M2xV55GKHBVQ==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.1.3",
-        "axios": "^1.2.1",
-        "compare-versions": "^5.0.1",
+        "axios": "^1.4.0",
+        "compare-versions": "^6.0.0",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^1.1.0",
@@ -8399,9 +8399,9 @@
       "dev": true
     },
     "compare-versions": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-5.0.1.tgz",
-      "integrity": "sha512-v8Au3l0b+Nwkp4G142JcgJFh1/TUhdxut7wzD1Nq1dyp5oa3tXaqb03EXOAB6jS4gMlalkjAUPZBMiAfKUixHQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.0.tgz",
+      "integrity": "sha512-LNZQXhqUvqUTotpZ00qLSaify3b4VFD588aRr8MKFw4CMUr98ytzCW5wDH5qx/DEY5kCDXcbcRuCqL0szEf2tg==",
       "dev": true
     },
     "compress-commons": {

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -58,7 +58,7 @@
     "@types/test-listen": "^1.1.0",
     "axe-test-fixtures": "github:dequelabs/axe-test-fixtures#v1",
     "chai": "^4.3.6",
-    "chromedriver": "^113.0.0",
+    "chromedriver": "^115.0.1",
     "cross-dirname": "^0.1.0",
     "delay": "^5.0.0",
     "express": "^4.18.2",

--- a/packages/webdriverjs/package-lock.json
+++ b/packages/webdriverjs/package-lock.json
@@ -21,7 +21,7 @@
         "@types/test-listen": "^1.1.0",
         "axe-test-fixtures": "github:dequelabs/axe-test-fixtures#v1",
         "chai": "^4.3.6",
-        "chromedriver": "latest",
+        "chromedriver": "^115.0.1",
         "express": "^4.18.2",
         "mocha": "^10.0.0",
         "nyc": "^15.1.0",
@@ -1298,7 +1298,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
     "node_modules/axe-core": {
@@ -1316,28 +1316,14 @@
       "license": "MPL-2.0"
     },
     "node_modules/axios": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.1.tgz",
-      "integrity": "sha512-I88cFiGu9ryt/tfVEi4kX2SITsvDddTajXTOFmt2uK1ZVA8LytjtdeyefdQWEf5PU8w+4SSJDoYnggflB5tW4A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
       "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/axios/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/balanced-match": {
@@ -1613,15 +1599,15 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "113.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-113.0.0.tgz",
-      "integrity": "sha512-UnQlt2kPicYXVNHPzy9HfcWvEbKJjjKAEaatdcnP/lCIRwuSoZFVLH0HVDAGdbraXp3dNVhfE2Qx7gw8TnHnPw==",
+      "version": "115.0.1",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-115.0.1.tgz",
+      "integrity": "sha512-faE6WvIhXfhnoZ3nAxUXYzeDCKy612oPwpkUp0mVkA7fZPg2JHSUiYOQhUYgzHQgGvDWD5Fy2+M2xV55GKHBVQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@testim/chrome-version": "^1.1.3",
-        "axios": "^1.2.1",
-        "compare-versions": "^5.0.1",
+        "axios": "^1.4.0",
+        "compare-versions": "^6.0.0",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^1.1.0",
@@ -1750,9 +1736,9 @@
       "dev": true
     },
     "node_modules/compare-versions": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-5.0.1.tgz",
-      "integrity": "sha512-v8Au3l0b+Nwkp4G142JcgJFh1/TUhdxut7wzD1Nq1dyp5oa3tXaqb03EXOAB6jS4gMlalkjAUPZBMiAfKUixHQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.0.tgz",
+      "integrity": "sha512-LNZQXhqUvqUTotpZ00qLSaify3b4VFD588aRr8MKFw4CMUr98ytzCW5wDH5qx/DEY5kCDXcbcRuCqL0szEf2tg==",
       "dev": true
     },
     "node_modules/concat-map": {
@@ -1889,7 +1875,7 @@
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -2305,9 +2291,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
       "dev": true,
       "funding": [
         {
@@ -2335,6 +2321,20 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -6138,7 +6138,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
     "axe-core": {
@@ -6152,27 +6152,14 @@
       "from": "axe-test-fixtures@github:dequelabs/axe-test-fixtures#v1"
     },
     "axios": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.1.tgz",
-      "integrity": "sha512-I88cFiGu9ryt/tfVEi4kX2SITsvDddTajXTOFmt2uK1ZVA8LytjtdeyefdQWEf5PU8w+4SSJDoYnggflB5tW4A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
       "dev": true,
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        }
       }
     },
     "balanced-match": {
@@ -6376,14 +6363,14 @@
       }
     },
     "chromedriver": {
-      "version": "113.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-113.0.0.tgz",
-      "integrity": "sha512-UnQlt2kPicYXVNHPzy9HfcWvEbKJjjKAEaatdcnP/lCIRwuSoZFVLH0HVDAGdbraXp3dNVhfE2Qx7gw8TnHnPw==",
+      "version": "115.0.1",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-115.0.1.tgz",
+      "integrity": "sha512-faE6WvIhXfhnoZ3nAxUXYzeDCKy612oPwpkUp0mVkA7fZPg2JHSUiYOQhUYgzHQgGvDWD5Fy2+M2xV55GKHBVQ==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.1.3",
-        "axios": "^1.2.1",
-        "compare-versions": "^5.0.1",
+        "axios": "^1.4.0",
+        "compare-versions": "^6.0.0",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^1.1.0",
@@ -6484,9 +6471,9 @@
       "dev": true
     },
     "compare-versions": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-5.0.1.tgz",
-      "integrity": "sha512-v8Au3l0b+Nwkp4G142JcgJFh1/TUhdxut7wzD1Nq1dyp5oa3tXaqb03EXOAB6jS4gMlalkjAUPZBMiAfKUixHQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.0.tgz",
+      "integrity": "sha512-LNZQXhqUvqUTotpZ00qLSaify3b4VFD588aRr8MKFw4CMUr98ytzCW5wDH5qx/DEY5kCDXcbcRuCqL0szEf2tg==",
       "dev": true
     },
     "concat-map": {
@@ -6604,7 +6591,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true
     },
     "depd": {
@@ -6920,9 +6907,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
       "dev": true
     },
     "foreground-child": {
@@ -6933,6 +6920,17 @@
       "requires": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^3.0.2"
+      }
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
       }
     },
     "forwarded": {

--- a/packages/webdriverjs/package.json
+++ b/packages/webdriverjs/package.json
@@ -75,7 +75,7 @@
     "@types/test-listen": "^1.1.0",
     "axe-test-fixtures": "github:dequelabs/axe-test-fixtures#v1",
     "chai": "^4.3.6",
-    "chromedriver": "latest",
+    "chromedriver": "^115.0.1",
     "express": "^4.18.2",
     "mocha": "^10.0.0",
     "nyc": "^15.1.0",


### PR DESCRIPTION
We shouldn't let tests run for large amounts of time: https://github.com/dequelabs/axe-core-npm/actions/runs/5790182483/job/15692791377 in case of hanging.

Set a default timeout for linting at 5min and integration tests at 15mins.