### PR TITLE
chore: use `latest` chromedriver where necessary

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@axe-core/webdriverjs": "^4.7.3",
         "axe-core": "^4.7.0",
-        "chromedriver": "^115.0.1",
+        "chromedriver": "latest",
         "colors": "^1.4.0",
         "commander": "^9.4.1",
         "selenium-webdriver": "^4.8.1"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@axe-core/webdriverjs": "^4.7.3",
     "axe-core": "^4.7.0",
-    "chromedriver": "^115.0.1",
+    "chromedriver": "latest",
     "colors": "^1.4.0",
     "commander": "^9.4.1",
     "selenium-webdriver": "^4.8.1"

--- a/packages/webdriverio/package-lock.json
+++ b/packages/webdriverio/package-lock.json
@@ -22,7 +22,7 @@
         "@types/test-listen": "^1.1.0",
         "axe-test-fixtures": "github:dequelabs/axe-test-fixtures#v1",
         "chai": "^4.3.6",
-        "chromedriver": "^115.0.1",
+        "chromedriver": "latest",
         "cross-dirname": "^0.1.0",
         "delay": "^5.0.0",
         "express": "^4.18.2",

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -58,7 +58,7 @@
     "@types/test-listen": "^1.1.0",
     "axe-test-fixtures": "github:dequelabs/axe-test-fixtures#v1",
     "chai": "^4.3.6",
-    "chromedriver": "^115.0.1",
+    "chromedriver": "latest",
     "cross-dirname": "^0.1.0",
     "delay": "^5.0.0",
     "express": "^4.18.2",


### PR DESCRIPTION
Always use latest at the point of install / clone, no need to pin to a specific version 