### PR TITLE
ci: fix deploy sha

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,7 @@ jobs:
             --canary \
             --dist-tag=next \
             --exact \
+            --preid=$(git rev-parse --short "$GITHUB_SHA") \
             --force-publish \
             --yes
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
             --canary \
             --dist-tag=next \
             --exact \
-            --preid=$(git rev-parse --short "$GITHUB_SHA") \
+            --preid=$(git rev-parse --short HEAD) \
             --force-publish \
             --yes
 


### PR DESCRIPTION
Lerna was generating SHAs that weren't compatible with npm tags. E.g `@axe-core/cli@4.7.4-alpha.0+8b5d296` which would be truncated to `@axe-core/cli@4.7.4-alpha.0` for npm. 