### PR TITLE
docs(README): fix error in example script

### DIFF
--- a/packages/webdriverjs/README.md
+++ b/packages/webdriverjs/README.md
@@ -26,7 +26,7 @@ const { Builder } = require('selenium-webdriver');
 const chrome = require('selenium-webdriver/chrome');
 
 (async () => {
-  const driver = Builder()
+  const driver = new Builder()
     .forBrowser('chrome')
     .setChromeOptions(new chrome.Options().headless())
     .build();


### PR DESCRIPTION
```
  const driver = Builder()
                 ^

TypeError: Class constructor Builder cannot be invoked without 'new'
```