### PR TITLE
Export AxeResults type from `@axe-core/playwright` package

### DIFF
--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -327,3 +327,4 @@ export default class AxeBuilder {
 }
 
 export { AxeBuilder };
+export type { AxeResults }


### PR DESCRIPTION
We had a need to get the `AxeResults` type, to pass to [`axe-sarif-converter`](https://www.npmjs.com/package/axe-sarif-converter) and we realized there is no good way to get the type without importing `axe-core` itself, or doing type gymnastics like:

```
import AxeBuilder from '@axe-core/playwright';
type AxeResultsType = ReturnType<AxeBuilder['analyze']> extends Promise<infer T> ? T : never;
```

Would you consider this PR to export AxeResults from the playwright package?

> For anyone who finds this, another approach, if specifically using `axe-sarif-converter` is:
> `type AxeResultsType = Parameters<typeof convertAxeToSarif>[0];`