### PR TITLE
ci: remove `bootstrap` step from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,6 @@ jobs:
           node-version: 18
           cache: 'npm'
       - run: npm ci
-      - run: npm run bootstrap
       # Make sure the working tree is clean
       - run: git reset --hard HEAD
       - run: npm config set "//registry.npmjs.org/:_authToken" ${{ secrets.NPM_TOKEN }}
@@ -43,7 +42,6 @@ jobs:
           node-version: 18
           cache: 'npm'
       - run: npm ci
-      - run: npm run bootstrap
       # Make sure the working tree is clean
       - run: git reset --hard HEAD
       - run: npm config set "//registry.npmjs.org/:_authToken" ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
with npm workspaces, we don't need `bootstrap` anymore