### PR TITLE
ci: update `prepare_release.sh` to take optional release level

### DIFF
--- a/.github/scripts/prepare_release.sh
+++ b/.github/scripts/prepare_release.sh
@@ -5,4 +5,10 @@ set -e
 
 releaseLevel="$1"
 
-npx lerna version "$releaseLevel" --conventional-commits --no-push --no-git-tag-version --yes
+# Let lerna handle versioning if "releaseLevel" is not provided.
+if [ -z "$releaseLevel" ] 
+then
+  npx lerna version --conventional-commits --no-push --no-git-tag-version --yes  
+else
+  npx lerna version "$releaseLevel" --conventional-commits --no-push --no-git-tag-version --yes
+fi


### PR DESCRIPTION
This PR allows the unnamed argument to be optional, if it's not specified it will default to lerna handling version, otherwise it will release as the specified release level. 

<details>
<summary>Without specifying a release level</summary>

<img width="962" alt="image" src="https://github.com/dequelabs/axe-core-npm/assets/41127686/d5d31a48-39eb-40ab-9d4c-684bb52d955d">

</details>

<details>
<summary>With release level</summary>

<img width="928" alt="image" src="https://github.com/dequelabs/axe-core-npm/assets/41127686/5e75113c-cd81-4138-89a1-a676c450a03f">


</details>


Closes: https://github.com/dequelabs/axe-core-npm/issues/850