### PR TITLE
ci: fix GH release workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,3 +59,4 @@ jobs:
             --title "Release $PKG_VERSION" \
             --generate-notes \
             --repo ${{ github.repository }}
+            --target master

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
             --yes
       - run: |
           PKG_VERSION=$(jq -r .version < lerna.json)
-          gh release create v$PKG_VERSION \
-            --title "Release v$PKG_VERSION" \
+          gh release create $PKG_VERSION \
+            --title "Release $PKG_VERSION" \
             --generate-notes \
             --repo ${{ github.repository }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,4 +53,9 @@ jobs:
           npx lerna publish from-package \
             --force-publish='*' \
             --yes
-      - uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
+      - run: |
+          PKG_VERSION=$(jq -r .version < lerna.json)
+          gh release create v$PKG_VERSION \
+            --title "Release v$PKG_VERSION" \
+            --generate-notes \
+            --repo ${{ github.repository }}


### PR DESCRIPTION
This replaces the implemented GHA that cuts a release in GitHub since the GHA requires a git branch to have the tag `refs/tags/` and when we cut the release we do not use the version as part of the release process
```
- uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
```
with the GitHub CLI https://cli.github.com/manual/gh_release_create
