### PR TITLE
chore: ignore commander dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,9 @@ updates:
         versions: ['>=6.0.0']
       - dependency-name: 'node-fetch'
         versions: ['>=3.0.0']
+      # Breaking change due to node version requirements
+      - dependency-name: 'commander'
+        versions: ['>=10.0.0']
     groups:
       # Any updates not caught by the group config will get individual PRs
       npm-low-risk:


### PR DESCRIPTION
Commander [v10](https://github.com/tj/commander.js/releases/tag/v10.0.0) requires node 14, commander [v11](https://github.com/tj/commander.js/releases/tag/v11.0.0) requires node 16. Both are breaking changes in our supported Node versions.