### PR TITLE
test: test built types export

### DIFF
--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -43,9 +43,10 @@
     "prebuild": "rimraf dist",
     "build": "tsup src/index.ts --dts --format esm,cjs",
     "test": "mocha --timeout 60000 -r ts-node/register 'test/**.spec.ts'",
-    "test:export": "npm run test:esm && npm run test:commonjs",
+    "test:export": "npm run test:esm && npm run test:commonjs && npm run test:ts",
     "test:esm": "node test/esmTest.mjs",
     "test:commonjs": "node test/commonjsTest.js",
+    "test:ts": "tsc test/tsTest.ts --noEmit --skipLibCheck --esModuleInterop",
     "coverage": "nyc npm run test",
     "prepare": "npx playwright install && npm run build"
   },

--- a/packages/playwright/test/tsTest.ts
+++ b/packages/playwright/test/tsTest.ts
@@ -1,0 +1,21 @@
+// This file isn't executed; we only care that typescript can successfully
+// build/typecheck. It is a smoke test that our build process is producing a
+// basically-reasonable index.d.ts.
+
+// Detailed tests of individual types should instead be covered by unit tests.
+
+import { AxeBuilder as NamedImportAxeBuilder } from '../dist/index.js';
+import DefaultImportAxeBuilder from '../dist/index.js';
+import type { Page } from 'playwright-core';
+
+// See https://stackoverflow.com/a/55541672
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+// If the imports don't have typings assigned, these will fail
+// with "ts(2322): Type 'false' is not assignable to type 'true'."
+(x: IsAny<typeof NamedImportAxeBuilder>): false => x;
+(x: IsAny<typeof DefaultImportAxeBuilder>): false => x;
+
+new NamedImportAxeBuilder({ page: {} as Page }).withRules('label').analyze();
+
+new DefaultImportAxeBuilder({ page: {} as Page }).withRules('label').analyze();

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -25,9 +25,10 @@
   "scripts": {
     "build": "tsup src/index.ts --dts --format esm,cjs",
     "test": "mocha --timeout 60000 -r ts-node/register 'test/**.spec.ts'",
-    "test:export": "npm run test:esm && npm run test:commonjs",
+    "test:export": "npm run test:esm && npm run test:commonjs && npm run test:ts",
     "test:esm": "node test/esmTest.mjs",
     "test:commonjs": "node test/commonjsTest.js",
+    "test:ts": "tsc test/tsTest.ts --noEmit --skipLibCheck --esModuleInterop",
     "coverage": "nyc npm run test",
     "prepublishOnly": "npm run build"
   },

--- a/packages/puppeteer/test/tsTest.ts
+++ b/packages/puppeteer/test/tsTest.ts
@@ -1,0 +1,21 @@
+// This file isn't executed; we only care that typescript can successfully
+// build/typecheck. It is a smoke test that our build process is producing a
+// basically-reasonable index.d.ts.
+
+// Detailed tests of individual types should instead be covered by unit tests.
+
+import { AxePuppeteer as NamedImportAxeBuilder } from '../dist/index.js';
+import DefaultImportAxeBuilder from '../dist/index.js';
+import type { Page } from 'puppeteer';
+
+// See https://stackoverflow.com/a/55541672
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+// If the imports don't have typings assigned, these will fail
+// with "ts(2322): Type 'false' is not assignable to type 'true'."
+(x: IsAny<typeof NamedImportAxeBuilder>): false => x;
+(x: IsAny<typeof DefaultImportAxeBuilder>): false => x;
+
+new NamedImportAxeBuilder({} as Page).withRules('label').analyze();
+
+new DefaultImportAxeBuilder({} as Page).withRules('label').analyze();

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,9 +28,10 @@
     "build": "tsup index.ts --dts --format esm,cjs",
     "prepare": "npm run build",
     "test": "tsc && npm run test:types && jest",
-    "test:export": "npm run test:esm && npm run test:commonjs",
+    "test:export": "npm run test:esm && npm run test:commonjs && npm run test:ts",
     "test:esm": "node test/esmTest.mjs",
     "test:commonjs": "node test/commonjsTest.js",
+    "test:ts": "tsc test/tsTest.ts --noEmit --skipLibCheck --esModuleInterop",
     "test:types": "cd test && tsc"
   },
   "keywords": [

--- a/packages/react/test/tsTest.ts
+++ b/packages/react/test/tsTest.ts
@@ -1,0 +1,18 @@
+// This file isn't executed; we only care that typescript can successfully
+// build/typecheck. It is a smoke test that our build process is producing a
+// basically-reasonable index.d.ts.
+
+// Detailed tests of individual types should instead be covered by unit tests.
+
+import reactAxe from '../dist/index.js';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+// See https://stackoverflow.com/a/55541672
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+// If the imports don't have typings assigned, these will fail
+// with "ts(2322): Type 'false' is not assignable to type 'true'."
+(x: IsAny<typeof reactAxe>): false => x;
+
+reactAxe(React, ReactDOM, 1000);

--- a/packages/reporter-earl/package.json
+++ b/packages/reporter-earl/package.json
@@ -15,9 +15,10 @@
   "scripts": {
     "start": "NODE_OPTIONS=--experimental-vm-modules jest --watch --env=jsdom",
     "test": "npm run build && npm run test:unit",
-    "test:export": "npm run test:esm && npm run test:commonjs",
+    "test:export": "npm run test:esm && npm run test:commonjs && npm run test:ts",
     "test:esm": "node tests/esmTest.mjs",
     "test:commonjs": "node tests/commonjsTest.js",
+    "test:ts": "tsc tests/tsTest.ts --noEmit --skipLibCheck --esModuleInterop",
     "test:unit": "NODE_OPTIONS=--experimental-vm-modules jest --collectCoverage",
     "build": "tsup src/axeReporterEarl.ts --dts --format esm,cjs",
     "prepublishOnly": "npm run build"

--- a/packages/reporter-earl/tests/tsTest.ts
+++ b/packages/reporter-earl/tests/tsTest.ts
@@ -1,0 +1,18 @@
+// This file isn't executed; we only care that typescript can successfully
+// build/typecheck. It is a smoke test that our build process is producing a
+// basically-reasonable index.d.ts.
+
+// Detailed tests of individual types should instead be covered by unit tests.
+
+import DefaultImportReporter from '../dist/axeReporterEarl.js';
+// import axe from 'axe-core';
+
+// See https://stackoverflow.com/a/55541672
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+// If the imports don't have typings assigned, these will fail
+// with "ts(2322): Type 'false' is not assignable to type 'true'."
+(x: IsAny<typeof DefaultImportReporter>): false => x;
+
+// TODO: this doesn't work as our types are broken
+// axe.configure({ reporter: DefaultImportReporter });

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -29,9 +29,10 @@
     "prebuild": "rimraf dist",
     "build": "tsup src/index.ts --dts --format esm,cjs",
     "test": "mocha --timeout 60000 -r ts-node/register 'test/**.spec.ts'",
-    "test:export": "npm run test:esm && npm run test:commonjs",
+    "test:export": "npm run test:esm && npm run test:commonjs && npm run test:ts",
     "test:esm": "node test/esmTest.mjs",
     "test:commonjs": "node test/commonjsTest.js",
+    "test:ts": "tsc test/tsTest.ts --noEmit --skipLibCheck --esModuleInterop",
     "coverage": "nyc npm run test",
     "prepare": "npm run build"
   },

--- a/packages/webdriverio/test/tsTest.ts
+++ b/packages/webdriverio/test/tsTest.ts
@@ -1,0 +1,25 @@
+// This file isn't executed; we only care that typescript can successfully
+// build/typecheck. It is a smoke test that our build process is producing a
+// basically-reasonable index.d.ts.
+
+// Detailed tests of individual types should instead be covered by unit tests.
+
+import { AxeBuilder as NamedImportAxeBuilder } from '../dist/index.js';
+import DefaultImportAxeBuilder from '../dist/index.js';
+import type { Browser } from 'webdriverio';
+
+// See https://stackoverflow.com/a/55541672
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+// If the imports don't have typings assigned, these will fail
+// with "ts(2322): Type 'false' is not assignable to type 'true'."
+(x: IsAny<typeof NamedImportAxeBuilder>): false => x;
+(x: IsAny<typeof DefaultImportAxeBuilder>): false => x;
+
+new NamedImportAxeBuilder({ client: {} as Browser })
+  .withRules('label')
+  .analyze();
+
+new DefaultImportAxeBuilder({ client: {} as Browser })
+  .withRules('label')
+  .analyze();

--- a/packages/webdriverjs/package.json
+++ b/packages/webdriverjs/package.json
@@ -49,9 +49,10 @@
     "prebuild": "rimraf dist",
     "build": "tsup src/index.ts --dts --format esm,cjs",
     "test": "mocha --timeout 60000 -r ts-node/register 'test/**.spec.ts'",
-    "test:export": "npm run test:esm && npm run test:commonjs",
+    "test:export": "npm run test:esm && npm run test:commonjs && npm run test:ts",
     "test:esm": "node test/esmTest.mjs",
     "test:commonjs": "node test/commonjsTest.js",
+    "test:ts": "tsc test/tsTest.ts --noEmit --skipLibCheck --esModuleInterop",
     "coverage": "nyc npm run test",
     "prepare": "npm run build"
   },

--- a/packages/webdriverjs/test/tsTest.ts
+++ b/packages/webdriverjs/test/tsTest.ts
@@ -1,0 +1,21 @@
+// This file isn't executed; we only care that typescript can successfully
+// build/typecheck. It is a smoke test that our build process is producing a
+// basically-reasonable index.d.ts.
+
+// Detailed tests of individual types should instead be covered by unit tests.
+
+import { AxeBuilder as NamedImportAxeBuilder } from '../dist/index.js';
+import DefaultImportAxeBuilder from '../dist/index.js';
+import type { WebDriver } from 'selenium-webdriver';
+
+// See https://stackoverflow.com/a/55541672
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+// If the imports don't have typings assigned, these will fail
+// with "ts(2322): Type 'false' is not assignable to type 'true'."
+(x: IsAny<typeof NamedImportAxeBuilder>): false => x;
+(x: IsAny<typeof DefaultImportAxeBuilder>): false => x;
+
+new NamedImportAxeBuilder({} as WebDriver).withRules('label').analyze();
+
+new DefaultImportAxeBuilder({} as WebDriver).withRules('label').analyze();


### PR DESCRIPTION
Add [typescript export tests](https://github.com/dequelabs/axe-core-npm/pull/927#pullrequestreview-1738072472) to all our packages. In so doing discovered https://github.com/dequelabs/axe-core-npm/issues/944.