### PR TITLE
chore: ignore esm package updates for delay and tempy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,10 @@ updates:
         versions: ['>=6.0.0']
       - dependency-name: 'node-fetch'
         versions: ['>=3.0.0']
+      - dependency-name: 'delay'
+        versions: ['>=6.0.0']
+      - dependency-name: 'tempy'
+        versions: ['>=2.0.0']
       # Breaking change due to node version requirements
       - dependency-name: 'commander'
         versions: ['>=10.0.0']


### PR DESCRIPTION
* [tempy 2.0 is ESM only](https://github.com/sindresorhus/tempy/releases/tag/v2.0.0)
* [delay 6.0 is ESM only](https://github.com/sindresorhus/delay/releases/tag/v6.0.0)

No QA needed