### PR TITLE
chore(dependabot): ignore esm chai >= 5.0.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,8 @@ updates:
         versions: ['>=6.0.0']
       - dependency-name: 'tempy'
         versions: ['>=2.0.0']
+      - dependency-name: 'chai'
+        versions: ['>=5.0.0']
       # Breaking change due to node version requirements
       - dependency-name: 'commander'
         versions: ['>=10.0.0']


### PR DESCRIPTION
[Chai 5.0.0 moved to ESM](https://github.com/chaijs/chai/releases/tag/v5.0.0).

Closes: https://github.com/dequelabs/axe-core-npm/pull/972