### PR TITLE
fix(webdriverjs): use new headless argument to fix selenium-webdriver@4.17.0 breaking release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22641,9 +22641,9 @@
       "dev": true
     },
     "node_modules/selenium-webdriver": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.16.0.tgz",
-      "integrity": "sha512-IbqpRpfGE7JDGgXHJeWuCqT/tUqnLvZ14csSwt+S8o4nJo3RtQoE9VR4jB47tP/A8ArkYsh/THuMY6kyRP6kuA==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.17.0.tgz",
+      "integrity": "sha512-e2E+2XBlGepzwgFbyQfSwo9Cbj6G5fFfs9MzAS00nC99EewmcS2rwn2MwtgfP7I5p1e7DYv4HQJXtWedsu6DvA==",
       "dependencies": {
         "jszip": "^3.10.1",
         "tmp": "^0.2.1",
@@ -26201,10 +26201,10 @@
       "dependencies": {
         "@axe-core/webdriverjs": "^4.8.3",
         "axe-core": "~4.8.3",
-        "chromedriver": "*",
+        "chromedriver": "latest",
         "colors": "^1.4.0",
         "commander": "^9.4.1",
-        "selenium-webdriver": "^4.8.1"
+        "selenium-webdriver": "~4.17.0"
       },
       "bin": {
         "axe": "dist/src/bin/cli.js"
@@ -26359,7 +26359,7 @@
         "async-listen": "^3.0.1",
         "axe-test-fixtures": "github:dequelabs/axe-test-fixtures#v1",
         "chai": "^4.3.6",
-        "chromedriver": "*",
+        "chromedriver": "latest",
         "cross-dirname": "^0.1.0",
         "delay": "^5.0.0",
         "devtools": "^8.27.2",
@@ -26394,7 +26394,7 @@
         "async-listen": "^3.0.1",
         "axe-test-fixtures": "github:dequelabs/axe-test-fixtures#v1",
         "chai": "^4.3.6",
-        "chromedriver": "*",
+        "chromedriver": "latest",
         "express": "^4.18.2",
         "mocha": "^10.0.0",
         "nyc": "^15.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,7 +52,7 @@
     "chromedriver": "latest",
     "colors": "^1.4.0",
     "commander": "^9.4.1",
-    "selenium-webdriver": "^4.8.1"
+    "selenium-webdriver": "~4.17.0"
   },
   "devDependencies": {
     "@types/chai": "^4.3.3",

--- a/packages/cli/src/lib/webdriver.test.ts
+++ b/packages/cli/src/lib/webdriver.test.ts
@@ -72,7 +72,7 @@ describe('startDriver', () => {
     const options = config?.builder?.getChromeOptions();
     assert.isArray(options?.get('goog:chromeOptions').args);
     assert.deepEqual(options?.get('goog:chromeOptions').args, [
-      '--headless',
+      'headless',
       '--no-sandbox'
     ]);
   });
@@ -85,7 +85,7 @@ describe('startDriver', () => {
     const options = config?.builder?.getChromeOptions();
     assert.isArray(options?.get('goog:chromeOptions').args);
     assert.deepEqual(options?.get('goog:chromeOptions').args, [
-      '--headless',
+      'headless',
       'no-sandbox',
       'disable-dev-shm-usage'
     ]);

--- a/packages/cli/src/lib/webdriver.test.ts
+++ b/packages/cli/src/lib/webdriver.test.ts
@@ -72,7 +72,7 @@ describe('startDriver', () => {
     const options = config?.builder?.getChromeOptions();
     assert.isArray(options?.get('goog:chromeOptions').args);
     assert.deepEqual(options?.get('goog:chromeOptions').args, [
-      '--headless=new',
+      '--headless',
       '--no-sandbox'
     ]);
   });
@@ -85,7 +85,7 @@ describe('startDriver', () => {
     const options = config?.builder?.getChromeOptions();
     assert.isArray(options?.get('goog:chromeOptions').args);
     assert.deepEqual(options?.get('goog:chromeOptions').args, [
-      '--headless=new',
+      '--headless',
       'no-sandbox',
       'disable-dev-shm-usage'
     ]);

--- a/packages/cli/src/lib/webdriver.test.ts
+++ b/packages/cli/src/lib/webdriver.test.ts
@@ -72,7 +72,7 @@ describe('startDriver', () => {
     const options = config?.builder?.getChromeOptions();
     assert.isArray(options?.get('goog:chromeOptions').args);
     assert.deepEqual(options?.get('goog:chromeOptions').args, [
-      'headless',
+      '--headless=new',
       '--no-sandbox'
     ]);
   });
@@ -85,7 +85,7 @@ describe('startDriver', () => {
     const options = config?.builder?.getChromeOptions();
     assert.isArray(options?.get('goog:chromeOptions').args);
     assert.deepEqual(options?.get('goog:chromeOptions').args, [
-      'headless',
+      '--headless=new',
       'no-sandbox',
       'disable-dev-shm-usage'
     ]);

--- a/packages/cli/src/lib/webdriver.ts
+++ b/packages/cli/src/lib/webdriver.ts
@@ -22,7 +22,7 @@ const startDriver = async (
     }
     // selenium-webdriver >= 4.17.0
     else {
-      options.addArguments('--headless');
+      options.addArguments('headless');
     }
 
     if (config.chromeOptions?.length) {

--- a/packages/cli/src/lib/webdriver.ts
+++ b/packages/cli/src/lib/webdriver.ts
@@ -22,7 +22,7 @@ const startDriver = async (
     }
     // selenium-webdriver >= 4.17.0
     else {
-      options.addArguments('--headless=new');
+      options.addArguments('--headless');
     }
 
     if (config.chromeOptions?.length) {

--- a/packages/cli/src/lib/webdriver.ts
+++ b/packages/cli/src/lib/webdriver.ts
@@ -15,7 +15,16 @@ const startDriver = async (
       config.chromedriverPath || chromedriver.path
     );
 
-    let options = new chrome.Options().headless();
+    let options = new chrome.Options();
+    // selenium-webdriver < 4.17.0
+    if (typeof options.headless === 'function') {
+      options.headless();
+    }
+    // selenium-webdriver >= 4.17.0
+    else {
+      options.addArguments('--headless=new');
+    }
+
     if (config.chromeOptions?.length) {
       options = config.chromeOptions.reduce(function (options, arg) {
         return options.addArguments(arg);

--- a/packages/webdriverjs/test/test-utils.ts
+++ b/packages/webdriverjs/test/test-utils.ts
@@ -5,7 +5,7 @@ import chrome from 'selenium-webdriver/chrome';
 export const Webdriver = (): WebDriver => {
   const builder = new Builder()
     .forBrowser('chrome')
-    .setChromeOptions(new chrome.Options().headless())
+    .setChromeOptions(new chrome.Options().addArguments('--headless=new'))
     .setChromeService(
       new chrome.ServiceBuilder(
         process.env.CHROMEDRIVER_PATH || chromedriver.path

--- a/packages/webdriverjs/test/test-utils.ts
+++ b/packages/webdriverjs/test/test-utils.ts
@@ -5,7 +5,7 @@ import chrome from 'selenium-webdriver/chrome';
 export const Webdriver = (): WebDriver => {
   const builder = new Builder()
     .forBrowser('chrome')
-    .setChromeOptions(new chrome.Options().addArguments('--headless=new'))
+    .setChromeOptions(new chrome.Options().addArguments('--headless'))
     .setChromeService(
       new chrome.ServiceBuilder(
         process.env.CHROMEDRIVER_PATH || chromedriver.path

--- a/packages/webdriverjs/test/test-utils.ts
+++ b/packages/webdriverjs/test/test-utils.ts
@@ -5,7 +5,7 @@ import chrome from 'selenium-webdriver/chrome';
 export const Webdriver = (): WebDriver => {
   const builder = new Builder()
     .forBrowser('chrome')
-    .setChromeOptions(new chrome.Options().addArguments('--headless'))
+    .setChromeOptions(new chrome.Options().addArguments('headless'))
     .setChromeService(
       new chrome.ServiceBuilder(
         process.env.CHROMEDRIVER_PATH || chromedriver.path


### PR DESCRIPTION
[Selenium-webdriver@4.17.0](https://github.com/SeleniumHQ/selenium/blob/trunk/javascript/node/selenium-webdriver/CHANGES.md#4170) released a breaking change that removed the deprecated function to call `setHeadless` or `headless`. Fixed by using the [new `addArugments`](https://www.selenium.dev/blog/2023/headless-is-going-away/) with `--headless`, and feature detecting the function before calling it in order to support older versions of selenium.

Also patched pin to selenium-webdriver as [they do not follow semver](https://github.com/SeleniumHQ/selenium/issues/12241#issuecomment-1602282881) and can release breaking changes in minor versions.

Closes: https://github.com/dequelabs/axe-core-npm/issues/991