### PR TITLE
chore: remove circleci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # axe-core-npm
 
-[![CircleCI](https://circleci.com/gh/dequelabs/axe-core-npm.svg?style=svg&circle-token=5bd96056d8ab9f52737de9b5d7cc614decbb9819)](https://circleci.com/gh/dequelabs/axe-core-npm)
 [![Join our Slack chat](https://img.shields.io/badge/slack-chat-purple.svg?logo=slack)](https://accessibility.deque.com/axe-community)
 
 This repository contains 7 packages, which can be used for automated accessibility testing powered by [axe core][axe-core].


### PR DESCRIPTION
This repo switched over to GHA from circleci

no qa required