### PR TITLE
test(cli): add test to cover selenium-webdriver <4.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5473,9 +5473,9 @@
       }
     },
     "node_modules/@types/sinon": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.2.tgz",
-      "integrity": "sha512-Zt6heIGsdqERkxctIpvN5Pv3edgBrhoeb3yHyxffd4InN0AX2SVNKSrhdDZKGQICVOxWP/q4DyhpfPNMSrpIiA==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.3.tgz",
+      "integrity": "sha512-j3uovdn8ewky9kRBG19bOwaZbexJu/XjtkHyjvUgt4xfPFz18dcORIMqnYh66Fx3Powhcr85NT5+er3+oViapw==",
       "dev": true,
       "dependencies": {
         "@types/sinonjs__fake-timers": "*"
@@ -29864,11 +29864,13 @@
         "@types/chromedriver": "^81.0.1",
         "@types/mocha": "^10.0.0",
         "@types/selenium-webdriver": "^4.1.5",
+        "@types/sinon": "^17.0.3",
         "chai": "^4.3.6",
         "execa": "5.1.1",
         "mocha": "^10.0.0",
         "nyc": "^15.1.0",
         "rimraf": "^5.0.5",
+        "sinon": "^17.0.1",
         "tempy": "^1.0.0",
         "ts-node": "^10.9.1",
         "typescript": "^5.2.2"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -59,11 +59,13 @@
     "@types/chromedriver": "^81.0.1",
     "@types/mocha": "^10.0.0",
     "@types/selenium-webdriver": "^4.1.5",
+    "@types/sinon": "^17.0.3",
     "chai": "^4.3.6",
     "execa": "5.1.1",
     "mocha": "^10.0.0",
     "nyc": "^15.1.0",
     "rimraf": "^5.0.5",
+    "sinon": "^17.0.1",
     "tempy": "^1.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2"

--- a/packages/cli/src/lib/axe-test-urls.ts
+++ b/packages/cli/src/lib/axe-test-urls.ts
@@ -19,7 +19,7 @@ const testPages = async (
     const currentUrl = urls[0].replace(/[,;]$/, '');
 
     if (events?.onTestStart) {
-      events?.onTestStart(currentUrl);
+      events.onTestStart(currentUrl);
     }
 
     if (config.timer) {

--- a/packages/cli/src/lib/utils.test.ts
+++ b/packages/cli/src/lib/utils.test.ts
@@ -3,7 +3,6 @@ import { assert } from 'chai';
 import tempy from 'tempy';
 import { join } from 'path';
 import { mkdirSync, writeFileSync, rmSync } from 'fs';
-import { dependencies } from '../../package.json';
 import * as utils from './utils';
 
 describe('utils', () => {
@@ -83,11 +82,7 @@ describe('utils', () => {
         writeFileSync(join(parentDirname, 'axe.js'), 'parent');
 
         const cliDirname = join(tempDir, 'packages', 'cli');
-        const nodeModDirname = join(
-          cliDirname,
-          'node_modules',
-          'axe-core'
-        );
+        const nodeModDirname = join(cliDirname, 'node_modules', 'axe-core');
         mkdirSync(nodeModDirname, { recursive: true });
         writeFileSync(join(nodeModDirname, 'axe.js'), 'node modules');
 

--- a/packages/cli/src/lib/webdriver.test.ts
+++ b/packages/cli/src/lib/webdriver.test.ts
@@ -4,9 +4,10 @@ import { startDriver } from './webdriver';
 import { WebDriver } from 'selenium-webdriver';
 import chromedriver from 'chromedriver';
 import chrome from 'selenium-webdriver/chrome';
-import type { Options } from 'selenium-webdriver/chrome';
 import path from 'path';
 import { WebdriverConfigParams } from '../types';
+import sinon from 'sinon';
+
 describe('startDriver', () => {
   let config: WebdriverConfigParams;
   let browser: string;
@@ -100,5 +101,15 @@ describe('startDriver', () => {
 
     assert.isObject(timeoutValue);
     assert.deepEqual(timeoutValue.script, 10000000);
+  });
+
+  it('test headless option in selenium-webdriver < 4.17.0', async () => {
+    const stub = sinon.stub(chrome, 'Options').returns({
+      headless: () => {}
+    });
+
+    driver = await startDriver(config);
+    assert.isTrue(stub.calledOnce);
+    stub.restore();
   });
 });

--- a/packages/cli/src/lib/webdriver.test.ts
+++ b/packages/cli/src/lib/webdriver.test.ts
@@ -107,8 +107,9 @@ describe('startDriver', () => {
     const stub = sinon.stub(chrome, 'Options').returns({
       headless: () => {}
     });
-
-    driver = await startDriver(config);
+    try {
+      driver = await startDriver(config);
+    } catch (error) {}
     assert.isTrue(stub.calledOnce);
     stub.restore();
   });

--- a/packages/cli/src/lib/webdriver.test.ts
+++ b/packages/cli/src/lib/webdriver.test.ts
@@ -23,7 +23,9 @@ describe('startDriver', () => {
   });
 
   afterEach(async () => {
-    await driver.quit();
+    try {
+      await driver.quit();
+    } catch (error) {}
   });
 
   it('creates a driver', async () => {

--- a/packages/cli/src/lib/webdriver.test.ts
+++ b/packages/cli/src/lib/webdriver.test.ts
@@ -23,6 +23,8 @@ describe('startDriver', () => {
   });
 
   afterEach(async () => {
+    // try catch required due to `chrome.options` being mocked with sinon
+    // and not properly creating a driver
     try {
       await driver.quit();
     } catch (error) {}
@@ -109,6 +111,9 @@ describe('startDriver', () => {
     const stub = sinon.stub(chrome, 'Options').returns({
       headless: () => {}
     });
+
+    // try catch required due to `chrome.options` being mocked with sinon
+    // and not properly creating a driver
     try {
       driver = await startDriver(config);
     } catch (error) {}


### PR DESCRIPTION
Add a test to cover the event that users are using selenium-webdriver <4.17.0 and chrome options use the "old" way of supporting headless runs. Also did some cleanup and removed code that wasn't required in cli

no qa required