### PR TITLE
test: fix tests for handling lazy iframe

### DIFF
--- a/packages/puppeteer/test/axe-puppeteer.spec.ts
+++ b/packages/puppeteer/test/axe-puppeteer.spec.ts
@@ -882,19 +882,22 @@ describe('AxePuppeteer', function () {
         .options({ runOnly: ['label', 'frame-tested'] })
         .analyze();
 
+      assert.equal(res?.status(), 200);
+
       // puppeteer version 22 (regardless of chrome version) is able to load
       // lazy loaded iframes and run axe on them without timing out, but we
       // still want to test that our code works with versions <22 to handle
       // the iframe by giving a frame-tested incomplete
       const [majorVersion] = version.split('.').map(Number);
       if (majorVersion < 22) {
-        assert.equal(res?.status(), 200);
         assert.equal(results.incomplete[0].id, 'frame-tested');
         assert.lengthOf(results.incomplete[0].nodes, 1);
         assert.deepEqual(results.incomplete[0].nodes[0].target, [
           '#ifr-lazy',
           '#lazy-iframe'
         ]);
+      } else {
+        assert.isEmpty(results.incomplete);
       }
 
       assert.equal(results.violations[0].id, 'label');

--- a/packages/puppeteer/test/axe-puppeteer.spec.ts
+++ b/packages/puppeteer/test/axe-puppeteer.spec.ts
@@ -15,6 +15,7 @@ import {
   expectAsyncToNotThrow
 } from './utils';
 import { fixturesPath } from 'axe-test-fixtures';
+import { setTimeout as promiseTimeout } from 'timers/promises';
 
 type SinonSpy = sinon.SinonSpy;
 
@@ -23,12 +24,6 @@ declare global {
     parallel?: boolean;
   }
 }
-
-const sleep = function (n: number) {
-  return new Promise(resolve => {
-    setTimeout(resolve, n);
-  });
-};
 
 describe('AxePuppeteer', function () {
   let browser: Browser;
@@ -885,7 +880,7 @@ describe('AxePuppeteer', function () {
       const res = await page.goto(`${addr}/lazy-loaded-iframe.html`);
 
       // allow time for the top-level iframe to load
-      await sleep(1000);
+      await promiseTimeout(1000);
 
       const results = await new AxePuppeteer(page)
         .options({ runOnly: ['label', 'frame-tested'] })

--- a/packages/puppeteer/test/axe-puppeteer.spec.ts
+++ b/packages/puppeteer/test/axe-puppeteer.spec.ts
@@ -15,7 +15,6 @@ import {
   expectAsyncToNotThrow
 } from './utils';
 import { fixturesPath } from 'axe-test-fixtures';
-import { version } from 'puppeteer/package.json';
 
 type SinonSpy = sinon.SinonSpy;
 
@@ -884,12 +883,16 @@ describe('AxePuppeteer', function () {
 
       assert.equal(res?.status(), 200);
 
-      // puppeteer version 22 (regardless of chrome version) is able to load
+      // chrome version 124 (regardless of webdriver version) is able to load
       // lazy loaded iframes and run axe on them without timing out, but we
-      // still want to test that our code works with versions <22 to handle
+      // still want to test that our code works with versions <124 to handle
       // the iframe by giving a frame-tested incomplete
-      const [majorVersion] = version.split('.').map(Number);
-      if (majorVersion < 22) {
+      const browserVersion = await page.browser().version();
+      const [majorVersion] = browserVersion
+        .substr(browserVersion.indexOf('/') + 1)
+        .split('.')
+        .map(Number);
+      if (majorVersion < 124) {
         assert.equal(results.incomplete[0].id, 'frame-tested');
         assert.lengthOf(results.incomplete[0].nodes, 1);
         assert.deepEqual(results.incomplete[0].nodes[0].target, [
@@ -897,6 +900,7 @@ describe('AxePuppeteer', function () {
           '#lazy-iframe'
         ]);
       } else {
+        assert.equal(results.passes[0].id, 'frame-tested');
         assert.isEmpty(results.incomplete);
       }
 

--- a/packages/puppeteer/tsconfig.json
+++ b/packages/puppeteer/tsconfig.json
@@ -1,24 +1,4 @@
 {
-  "compilerOptions": {
-    /* Basic Options */
-    "target": "esnext",
-    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
-    "lib": [
-      "dom",
-      "esnext"
-    ] /* Specify library files to be included in the compilation. */,
-    "declaration": true /* Generates corresponding '.d.ts' file. */,
-    "sourceMap": true /* Generates corresponding '.map' file. */,
-    "outDir": "dist" /* Redirect output structure to the directory. */,
-    "rootDir": "src" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
-    "removeComments": true /* Do not emit comments to output. */,
-    "pretty": true,
-    "strict": true,
-    "noImplicitAny": true,
-    "noImplicitThis": true,
-    "noImplicitReturns": true,
-    "moduleResolution": "node",
-    "esModuleInterop": true
-  },
+  "extends": "../../tsconfig.json",
   "include": ["src"]
 }

--- a/packages/webdriverio/test/axe-webdriverio.spec.ts
+++ b/packages/webdriverio/test/axe-webdriverio.spec.ts
@@ -48,7 +48,7 @@ const connectToChromeDriver = (port: number): Promise<void> => {
 
 describe('@axe-core/webdriverio', () => {
   let port: number;
-  for (const protocol of ['devtools'] as const) {
+  for (const protocol of ['devtools', 'webdriver'] as const) {
     if (protocol === 'webdriver') {
       port = 9515;
 

--- a/packages/webdriverio/test/axe-webdriverio.spec.ts
+++ b/packages/webdriverio/test/axe-webdriverio.spec.ts
@@ -893,12 +893,25 @@ describe('@axe-core/webdriverio', () => {
               .analyze();
 
             assert.notEqual(title, 'Error');
-            assert.equal(results.incomplete[0].id, 'frame-tested');
-            assert.lengthOf(results.incomplete[0].nodes, 1);
-            assert.deepEqual(results.incomplete[0].nodes[0].target, [
-              '#ifr-lazy',
-              '#lazy-iframe'
-            ]);
+
+            // chrome version 124 (regardless of webdriver version) is able to load
+            // lazy loaded iframes and run axe on them without timing out, but we
+            // still want to test that our code works with versions <124 to handle
+            // the iframe by giving a frame-tested incomplete
+            const [majorVersion] = client.capabilities.browserVersion
+              .split('.')
+              .map(Number);
+            if (majorVersion < 124) {
+              assert.equal(results.incomplete[0].id, 'frame-tested');
+              assert.lengthOf(results.incomplete[0].nodes, 1);
+              assert.deepEqual(results.incomplete[0].nodes[0].target, [
+                '#ifr-lazy',
+                '#lazy-iframe'
+              ]);
+            } else {
+              assert.isEmpty(results.incomplete);
+            }
+
             assert.equal(results.violations[0].id, 'label');
             assert.lengthOf(results.violations[0].nodes, 1);
             assert.deepEqual(results.violations[0].nodes[0].target, [

--- a/packages/webdriverio/test/axe-webdriverio.spec.ts
+++ b/packages/webdriverio/test/axe-webdriverio.spec.ts
@@ -14,6 +14,7 @@ import type { AxeResults, Result } from 'axe-core';
 import child_process from 'child_process';
 import { ChildProcessWithoutNullStreams } from 'child_process';
 import { fixturesPath } from 'axe-test-fixtures';
+import { setTimeout as promiseTimeout } from 'timers/promises';
 
 const connectToChromeDriver = (port: number): Promise<void> => {
   let socket: net.Socket;
@@ -43,12 +44,6 @@ const connectToChromeDriver = (port: number): Promise<void> => {
       socket.destroy();
       return reject(err);
     });
-  });
-};
-
-const sleep = function (n: number) {
-  return new Promise(resolve => {
-    setTimeout(resolve, n);
   });
 };
 
@@ -895,7 +890,7 @@ describe('@axe-core/webdriverio', () => {
             const title = await client.getTitle();
 
             // allow time for the top-level iframe to load
-            await sleep(1000);
+            await promiseTimeout(1000);
 
             const results = await new AxeBuilder({ client })
               .options({ runOnly: ['label', 'frame-tested'] })

--- a/packages/webdriverio/test/axe-webdriverio.spec.ts
+++ b/packages/webdriverio/test/axe-webdriverio.spec.ts
@@ -48,7 +48,7 @@ const connectToChromeDriver = (port: number): Promise<void> => {
 
 describe('@axe-core/webdriverio', () => {
   let port: number;
-  for (const protocol of ['devtools', 'webdriver'] as const) {
+  for (const protocol of ['devtools'] as const) {
     if (protocol === 'webdriver') {
       port = 9515;
 
@@ -909,6 +909,7 @@ describe('@axe-core/webdriverio', () => {
                 '#lazy-iframe'
               ]);
             } else {
+              assert.equal(results.passes[0].id, 'frame-tested');
               assert.isEmpty(results.incomplete);
             }
 

--- a/packages/webdriverjs/test/axe-webdriverjs.spec.ts
+++ b/packages/webdriverjs/test/axe-webdriverjs.spec.ts
@@ -390,6 +390,8 @@ describe('@axe-core/webdriverjs', () => {
         .options({ runOnly: ['label', 'frame-tested'] })
         .analyze();
 
+      assert.notEqual(title, 'Error');
+
       // chrome version 124 (regardless of webdriver version) is able to load
       // lazy loaded iframes and run axe on them without timing out, but we
       // still want to test that our code works with versions <124 to handle
@@ -400,7 +402,6 @@ describe('@axe-core/webdriverjs', () => {
         .split('.')
         .map(Number);
       if (majorVersion < 124) {
-        assert.notEqual(title, 'Error');
         assert.equal(results.incomplete[0].id, 'frame-tested');
         assert.lengthOf(results.incomplete[0].nodes, 1);
         assert.deepEqual(results.incomplete[0].nodes[0].target, [

--- a/packages/webdriverjs/test/axe-webdriverjs.spec.ts
+++ b/packages/webdriverjs/test/axe-webdriverjs.spec.ts
@@ -409,6 +409,7 @@ describe('@axe-core/webdriverjs', () => {
           '#lazy-iframe'
         ]);
       } else {
+        assert.equal(results.passes[0].id, 'frame-tested');
         assert.isEmpty(results.incomplete);
       }
 

--- a/packages/webdriverjs/test/axe-webdriverjs.spec.ts
+++ b/packages/webdriverjs/test/axe-webdriverjs.spec.ts
@@ -12,16 +12,11 @@ import { AxeBuilder } from '../src';
 import { axeRunPartial } from '../src/browser';
 import { fixturesPath } from 'axe-test-fixtures';
 import { Command, Name } from 'selenium-webdriver/lib/command';
+import { setTimeout as promiseTimeout } from 'timers/promises';
 
 const dylangConfig = JSON.parse(
   fs.readFileSync(path.join(fixturesPath, 'dylang-config.json'), 'utf8')
 );
-
-const sleep = function (n: number) {
-  return new Promise(resolve => {
-    setTimeout(resolve, n);
-  });
-};
 
 describe('@axe-core/webdriverjs', () => {
   let driver: WebDriver;
@@ -393,7 +388,7 @@ describe('@axe-core/webdriverjs', () => {
       const title = await driver.getTitle();
 
       // allow time for the top-level iframe to load
-      await sleep(1000);
+      await promiseTimeout(1000);
 
       const results = await new AxeBuilder(driver)
         .options({ runOnly: ['label', 'frame-tested'] })

--- a/packages/webdriverjs/test/axe-webdriverjs.spec.ts
+++ b/packages/webdriverjs/test/axe-webdriverjs.spec.ts
@@ -390,13 +390,27 @@ describe('@axe-core/webdriverjs', () => {
         .options({ runOnly: ['label', 'frame-tested'] })
         .analyze();
 
-      assert.notEqual(title, 'Error');
-      assert.equal(results.incomplete[0].id, 'frame-tested');
-      assert.lengthOf(results.incomplete[0].nodes, 1);
-      assert.deepEqual(results.incomplete[0].nodes[0].target, [
-        '#ifr-lazy',
-        '#lazy-iframe'
-      ]);
+      // chrome version 124 (regardless of webdriver version) is able to load
+      // lazy loaded iframes and run axe on them without timing out, but we
+      // still want to test that our code works with versions <124 to handle
+      // the iframe by giving a frame-tested incomplete
+      const capabilities = await driver.getCapabilities();
+      const [majorVersion] = capabilities
+        .get('browserVersion')
+        .split('.')
+        .map(Number);
+      if (majorVersion < 124) {
+        assert.notEqual(title, 'Error');
+        assert.equal(results.incomplete[0].id, 'frame-tested');
+        assert.lengthOf(results.incomplete[0].nodes, 1);
+        assert.deepEqual(results.incomplete[0].nodes[0].target, [
+          '#ifr-lazy',
+          '#lazy-iframe'
+        ]);
+      } else {
+        assert.isEmpty(results.incomplete);
+      }
+
       assert.equal(results.violations[0].id, 'label');
       assert.lengthOf(results.violations[0].nodes, 1);
       assert.deepEqual(results.violations[0].nodes[0].target, [


### PR DESCRIPTION
Chrome v124 now has the capability to load lazy loaded iframes. To support both older versions of chrome (e.g. installing older versions of playwright or puppeteer) we'll branch the test to look at the `frame-tested` rule in different places. Older versions will look in `incomplete`, newer versions will look in `passes`. Note that since the iframe is lazy loaded the page load event is fired before the frame is loaded, so I needed to add a delay after the page loaded to ensure the iframes were all settled (otherwise the tests were flakey).

At a later date we'll create a CI job that installs an older version of the chrome for each of the packages to ensure we don't have a regression going forward.

QA notes: test puppeteer version < 22 with lazy loaded iframe to see `frame-tested` as incomplete, test with latest version to see `frame-tested` as passes. For [webdevierio](https://webdriver.io/docs/capabilities/#binary) and [webdriverjs](https://www.selenium.dev/documentation/webdriver/browsers/chrome/#start-browser-in-a-specified-location) you'll need to set the chrome binary and/or chromedriver to a version < 124 to see `frame-tested` in incomplete, and the latest version to see `frame-tested` as passes.