### PR TITLE
chore: update test-fixtures to fix lazy load iframe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9970,8 +9970,7 @@
     },
     "node_modules/axe-test-fixtures": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/dequelabs/axe-test-fixtures.git#a8b90ebb4fe63fc76158d231c109d527471e698f",
-      "integrity": "sha512-PBK63f+4QooW0EVi9cxFEooEtiR5PiWCBq2TKes28ep5wh3huWCB125nL9dGozys10YwqpLSf4kZBXloJFK5QA==",
+      "resolved": "git+ssh://git@github.com/dequelabs/axe-test-fixtures.git#80fde4a947257461a2cc2d3dc746e9381dc59aa0",
       "dev": true,
       "license": "MPL-2.0"
     },
@@ -29851,7 +29850,7 @@
       "dependencies": {
         "@axe-core/webdriverjs": "^4.9.0",
         "axe-core": "~4.9.0",
-        "chromedriver": "*",
+        "chromedriver": "latest",
         "colors": "^1.4.0",
         "commander": "^9.4.1",
         "selenium-webdriver": "~4.17.0"
@@ -30011,7 +30010,7 @@
         "async-listen": "^3.0.1",
         "axe-test-fixtures": "github:dequelabs/axe-test-fixtures#v1",
         "chai": "^4.3.6",
-        "chromedriver": "*",
+        "chromedriver": "latest",
         "cross-dirname": "^0.1.0",
         "delay": "^5.0.0",
         "devtools": "^8.27.2",
@@ -30046,7 +30045,7 @@
         "async-listen": "^3.0.1",
         "axe-test-fixtures": "github:dequelabs/axe-test-fixtures#v1",
         "chai": "^4.3.6",
-        "chromedriver": "*",
+        "chromedriver": "latest",
         "express": "^4.18.2",
         "mocha": "^10.0.0",
         "nyc": "^15.1.0",


### PR DESCRIPTION
Fixes the broken lazy load iframe tests.

Ref: https://github.com/dequelabs/axe-core-npm/pull/1052

No QA needed.