### PR TITLE
fix(playwright): skip unloaded iframes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4511,12 +4511,12 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.40.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.40.1.tgz",
-      "integrity": "sha512-EaaawMTOeEItCRvfmkI9v6rBkF1svM8wjl/YPRrg2N2Wmp+4qJYkWtJsbew1szfKKDm6fPLy4YAanBhIlf9dWw==",
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.0.tgz",
+      "integrity": "sha512-rNX5lbNidamSUorBhB4XZ9SQTjAqfe5M+p37Z8ic0jPFBMo5iCtQz1kRWkEMg+rYOKSlVycpQmpqjSFq7LXOfg==",
       "dev": true,
       "dependencies": {
-        "playwright": "1.40.1"
+        "playwright": "1.44.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -24698,12 +24698,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.40.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.1.tgz",
-      "integrity": "sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==",
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.0.tgz",
+      "integrity": "sha512-F9b3GUCLQ3Nffrfb6dunPOkE5Mh68tR7zN32L4jCk4FjQamgesGay7/dAAe1WaMEGV04DkdJfcJzjoCKygUaRQ==",
       "dev": true,
       "dependencies": {
-        "playwright-core": "1.40.1"
+        "playwright-core": "1.44.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -24716,9 +24716,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.40.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.1.tgz",
-      "integrity": "sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==",
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.0.tgz",
+      "integrity": "sha512-ZTbkNpFfYcGWohvTTl+xewITm7EOuqIqex0c7dNZ+aXsbrLj0qI8XlGKfPpipjm0Wny/4Lt4CJsWJk1stVS5qQ==",
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -29886,7 +29886,7 @@
         "axe-core": "~4.9.0"
       },
       "devDependencies": {
-        "@playwright/test": "^1.34.3",
+        "@playwright/test": "^1.44.0",
         "@types/chai": "^4.3.3",
         "@types/express": "^4.17.14",
         "@types/mocha": "^10.0.0",

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -54,7 +54,7 @@
     "axe-core": "~4.9.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.34.3",
+    "@playwright/test": "^1.44.0",
     "@types/chai": "^4.3.3",
     "@types/express": "^4.17.14",
     "@types/mocha": "^10.0.0",

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -185,7 +185,14 @@ export default class AxeBuilder {
 
   private async inject(frames: Frame[]): Promise<void> {
     for (const iframe of frames) {
-      await iframe.evaluate(await this.script());
+      const race = new Promise((_, reject) => {
+        setTimeout(() => {
+          reject(new Error('Script Timeout'));
+        }, 1000);
+      });
+      const evaluate = iframe.evaluate(this.script());
+
+      await Promise.race([evaluate, race]);
       await iframe.evaluate(await this.axeConfigure());
     }
   }

--- a/packages/playwright/test/axe-playwright.spec.ts
+++ b/packages/playwright/test/axe-playwright.spec.ts
@@ -447,7 +447,12 @@ describe('@axe-core/playwright', () => {
         .analyze();
 
       assert.equal(res?.status(), 200);
-      assert.lengthOf(results.incomplete, 0);
+      assert.equal(results.incomplete[0].id, 'frame-tested');
+      assert.lengthOf(results.incomplete[0].nodes, 1);
+      assert.deepEqual(results.incomplete[0].nodes[0].target, [
+        '#ifr-lazy',
+        '#lazy-iframe'
+      ]);
       assert.equal(results.violations[0].id, 'label');
       assert.lengthOf(results.violations[0].nodes, 1);
       assert.deepEqual(results.violations[0].nodes[0].target, [


### PR DESCRIPTION
Pulled out of https://github.com/dequelabs/axe-core-npm/pull/1048. Starting in Playwright 1.41.0 (using Chrome version 121.0.6167.57) Playwright is no longer loading the lazy loaded iframe that is out of view. Updated the version  of Playwright and updated the tests to now account for this.

QA notes: Test a lazy loaded iframe with Playwright > 1.41.0 and ensure Playwright will complete an analyze of the page