### PR TITLE
fix(playwright): Add missing await on page.evaluate

### DIFF
--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -295,8 +295,8 @@ export default class AxeBuilder {
       'Please make sure that you have popup blockers disabled.'
     );
 
-    blankPage.evaluate(this.script());
-    blankPage.evaluate(await this.axeConfigure());
+    await blankPage.evaluate(this.script());
+    await blankPage.evaluate(await this.axeConfigure());
 
     // evaluate has a size limit on the number of characters so we'll need
     // to split partialResults into chunks if it exceeds that limit.

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -151,7 +151,7 @@ export default class AxeBuilder {
     const context = normalizeContext(this.includes, this.excludes);
     const { page } = this;
 
-    page.evaluate(this.script());
+    await page.evaluate(this.script());
     const runPartialDefined = await page.evaluate<boolean>(
       'typeof window.axe.runPartial === "function"'
     );


### PR DESCRIPTION
Hi,

This missing await causes us many, hard to debug problems, when page has been closed prematurely (popup or terminating analysis if too long)

Simple reproduction :
```ts
(async () => {
  const browser = await playwright.chromium.launch({ headless: true });
  const context = await browser.newContext();
  const page = await context.newPage();
  await page.close();
  try {
    const results = await new AxeBuilder({ page }).analyze();
    console.log(results);
  } catch (error) {
    console.error(error);
  }
  await browser.close();
})();
// node:internal/process/promises:279
            triggerUncaughtException(err, true /* fromPromise */);
            ^
 page.evaluate: Target page, context or browser has been closed
```

I haven't been able to write a simple test that reproduce the problem but I can reproduce it in my project and adding that await fixed all my problems

No QA needed