### PR TITLE
Playwright: Introduce configure method to AxeBuilder

### DIFF
--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -138,6 +138,32 @@ Skips verification of the rules provided. Accepts a String of a single rule ID o
 new AxeBuilder({ page }).disableRules('color-contrast');
 ```
 
+### AxeBuilder#configure(config: [axe.Spec](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#api-name-axeconfigure))
+
+Inject an axe configuration object to modify the ruleset before running Analyze. Subsequent calls to this method will invalidate previous ones by calling `axe.configure` and replacing the config object. See [axe-core API documentation](https://github.com/dequelabs/axe-core/blob/master/doc/API.md#api-name-axeconfigure) for documentation on the object structure.
+
+```js
+const config = {
+  locale: {
+    lang: 'de',
+    rules: {
+      'aria-hidden-body': {
+        description:
+          "Stellt sicher, dass aria-hidden='true' nicht am <body>-Element des Dokumentes verwendet wird.",
+        help: "Aria-hidden='true' darf nicht für den <body> des Dokumentes verwendet werden."
+      }
+    }
+  }
+};
+
+new AxeBuilder(driver).configure(config).analyze((err, results) => {
+  if (err) {
+    // Handle error somehow
+  }
+  console.log(results);
+});
+```
+
 ### AxeBuilder#setLegacyMode(legacyMode: boolean = true)
 
 Set the frame testing method to "legacy mode". In this mode, axe will not open a blank page in which to aggregate its results. This can be used in an environment where opening a blank page is causes issues.

--- a/packages/playwright/test/axe-playwright.spec.ts
+++ b/packages/playwright/test/axe-playwright.spec.ts
@@ -279,6 +279,54 @@ describe('@axe-core/playwright', () => {
     });
   });
 
+  describe('configure', () => {
+    it('provides results in default locale', async () => {
+      await page.goto(`${addr}/index.html`);
+      const results = await new AxeBuilder({ page }).analyze();
+      const pass = results.passes[0];
+
+      assert.strictEqual(pass.id, 'aria-hidden-body');
+      assert.strictEqual(
+        pass.description,
+        'Ensure aria-hidden="true" is not present on the document body.'
+      );
+      assert.strictEqual(
+        pass.help,
+        'aria-hidden="true" must not be present on the document body'
+      );
+    });
+
+    it('provides results in supplied locale', async () => {
+      await page.goto(`${addr}/index.html`);
+      const results = await new AxeBuilder({ page })
+        .configure({
+          locale: {
+            lang: 'de',
+            rules: {
+              'aria-hidden-body': {
+                description:
+                  "Stellt sicher, dass aria-hidden='true' nicht am <body>-Element des Dokumentes verwendet wird.",
+                help: "Aria-hidden='true' darf nicht für den <body> des Dokumentes verwendet werden."
+              }
+            }
+          }
+        })
+        .analyze();
+
+      const pass = results.passes[0];
+
+      assert.strictEqual(pass.id, 'aria-hidden-body');
+      assert.strictEqual(
+        pass.description,
+        "Stellt sicher, dass aria-hidden='true' nicht am <body>-Element des Dokumentes verwendet wird."
+      );
+      assert.strictEqual(
+        pass.help,
+        "Aria-hidden='true' darf nicht für den <body> des Dokumentes verwendet werden."
+      );
+    });
+  });
+
   describe('options', () => {
     it('passes options to axe-core', async () => {
       const res = await page.goto(`${addr}/index.html`);


### PR DESCRIPTION
# Goal 
Be able to specify different locales to axe-core via `@axe-core/playwright`

# Implementation
In `axe-core` locales are specified in the object parameter to the `axe.configure` method.

The `AxeBuilder` in `@axe-core/playwright` has a private method `axeConfigure` which calls `axe.configure`, however the private does not accept any parameter to pass onto `axe.configure`.

The new `configure` method was borrowed from `packages/webdriverjs` which has a slightly different implementation of `AxeBuilder`.

The main interesting part of the code was taking the supplied config object and using it inside `axeConfigure`.

# README
Again the update here was borrowed from `packages/webdriverjs` and the example has been updated.

# Something to double check
I suspect the original docs for `packages/webdriverjs` have incorrect or out of date parameters in the [example](https://github.com/dequelabs/axe-core-npm/blob/develop/packages/webdriverjs/README.md#axebuilderconfigureconfig-axespec) as rules are specified in the :options parameter to the `axe.run` method.


```
const config = {
  checks: axe.Check[],
  rules: axe.Rule[]
}

new AxeBuilder(driver).configure(config)
```
