### PR TITLE
ci: resolve chromedrivers not running in Ubuntu runners >=24.04

### DIFF
--- a/packages/cli/src/lib/webdriver.ts
+++ b/packages/cli/src/lib/webdriver.ts
@@ -35,6 +35,9 @@ const startDriver = async (
 
     if (CHROME_TEST_PATH) {
       options.setChromeBinaryPath(path.resolve(CHROME_TEST_PATH));
+      // Required for CI runners using >=Ubuntu 24.04
+      // @see https://github.com/SeleniumHQ/selenium/issues/14609
+      options.addArguments('no-sandbox');
     }
 
     if (config.chromePath) {

--- a/packages/webdriverio/test/axe-webdriverio.spec.ts
+++ b/packages/webdriverio/test/axe-webdriverio.spec.ts
@@ -119,7 +119,12 @@ describe('@axe-core/webdriverio', () => {
           capabilities: {
             browserName: 'chrome',
             'goog:chromeOptions': {
-              args: ['--headless'],
+              args: [
+                '--headless',
+                // Required for CI runners using >=Ubuntu 24.04
+                // @see https://github.com/SeleniumHQ/selenium/issues/14609
+                '--no-sandbox'
+              ],
               binary: process.env.CHROME_TEST_PATH as string
             }
           },

--- a/packages/webdriverjs/test/test-utils.ts
+++ b/packages/webdriverjs/test/test-utils.ts
@@ -23,7 +23,12 @@ export const Webdriver = (): WebDriver => {
   // Weird type change since 4.23.1 release
   // @see https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/69724
   const options = new chrome.Options();
-  options.addArguments('headless');
+  options
+    .addArguments('headless')
+    // Required for CI runners using >=Ubuntu 24.04
+    // @see https://github.com/SeleniumHQ/selenium/issues/14609
+    .addArguments('no-sandbox');
+
   options.setBinaryPath(process.env.CHROME_TEST_PATH as string);
 
   const builder = new Builder()


### PR DESCRIPTION
This patch adds `--no-sandbox` chrome flag which was already added by default on previous versions of bun

Resolves this [error](https://github.com/dequelabs/axe-core-npm/actions/runs/12889457050/job/36296592750#step:6:403): 

> SessionNotCreatedError: session not created: probably user data directory is already in use, please specify a unique value for --user-data-dir argument, or don't use --user-data-dir

Related issues: https://github.com/SeleniumHQ/selenium/issues/14609

No QA required