### PR TITLE
fix: Optimize AxeBuilder memory usage.

### DIFF
--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -26,7 +26,7 @@ export default class AxeBuilder {
   private includes: SerialSelectorList;
   private excludes: SerialSelectorList;
   private option: RunOptions;
-  private source: string;
+  private axeSource: string | undefined;
   private legacyMode = false;
   private errorUrl: string;
 
@@ -35,7 +35,7 @@ export default class AxeBuilder {
     this.includes = [];
     this.excludes = [];
     this.option = {};
-    this.source = axeSource || source;
+    this.axeSource = axeSource;
     this.errorUrl =
       'https://github.com/dequelabs/axe-core-npm/blob/develop/packages/playwright/error-handling.md';
   }
@@ -210,7 +210,7 @@ export default class AxeBuilder {
    */
 
   private script(): string {
-    return this.source;
+    return this.axeSource || source;
   }
 
   private async runLegacy(context: SerialContextObject): Promise<AxeResults> {


### PR DESCRIPTION
If `AxeBuilder` is instantiated many times, each instance of the class will store the 250kb axe source string causing performance issues.

I looked at `@axe-core/puppeteer` and they follow the pattern in this PR:
- https://github.com/bensenescu/axe-core-npm/blob/develop/packages/puppeteer/src/axePuppeteer.ts#L59
- https://github.com/bensenescu/axe-core-npm/blob/develop/packages/puppeteer/src/utils.ts#L34

No QA required