### PR TITLE
fix: resolve blank navigation issue in WDIO v9

### DIFF
--- a/packages/webdriverio/src/index.ts
+++ b/packages/webdriverio/src/index.ts
@@ -369,7 +369,7 @@ export default class AxeBuilder {
 
     try {
       await client.switchToWindow(newWindow.handle);
-      await (client as WebdriverIO.Browser).url('about:blank');
+      await (client as WebdriverIO.Browser).url('data:text/html,');
     } catch (error) {
       throw new Error(
         `switchToWindow failed. Are you using updated browser drivers? \nDriver reported:\n${


### PR DESCRIPTION
After recent WDIO update to BiDi, navigation to about:blank fails in some cases. To address that, navigation to data:text/html, is added instead. Test cases passed.
No QA needed