### PR TITLE
chore(wdio): add webdriverio ^9 to peer dependencies

### DIFF
--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -76,7 +76,7 @@
     "webdriverio": "^8.8.2"
   },
   "peerDependencies": {
-    "webdriverio": "^5 || ^6 || ^7 || ^8"
+    "webdriverio": "^5 || ^6 || ^7 || ^8 || ^9"
   },
   "nyc": {
     "include": [


### PR DESCRIPTION
Closes #1160 

No QA required.