### PR TITLE
chore: add note about semver to READMEs

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,6 +4,8 @@ Provides a command line interface for [axe](https://github.com/dequelabs/axe-cor
 
 Previous versions of this program were maintained at [dequelabs/axe-cli](https://github.com/dequelabs/axe-cli).
 
+This package does not follow Semantic Versioning (SemVer) but instead uses the major and minor version (but not patch version) of axe-core that the package uses. For example, if the API version is v4.7.2, then the axe-core version used by the package will be v4.7.x. The patch version of this package may include bug fixes and new API features but will not introduce breaking changes.
+
 ## Getting Started
 
 Install [Node.js](https://docs.npmjs.com/getting-started/installing-node) if you haven't already. This project requires Node 6+. By default, axe-cli runs Chrome in headless mode, which requires Chrome 59 or up.

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -2,6 +2,8 @@
 
 > Provides a chainable axe API for playwright and automatically injects into all frames
 
+This package does not follow Semantic Versioning (SemVer) but instead uses the major and minor version (but not patch version) of axe-core that the package uses. For example, if the API version is v4.7.2, then the axe-core version used by the package will be v4.7.x. The patch version of this package may include bug fixes and new API features but will not introduce breaking changes.
+
 ## Getting Started
 
 Install [Node.js](https://docs.npmjs.com/getting-started/installing-node) if you haven't already.

--- a/packages/puppeteer/README.md
+++ b/packages/puppeteer/README.md
@@ -4,6 +4,8 @@ Provides a chainable axe API for Puppeteer and automatically injects into all fr
 
 Previous versions of this program were maintained at [dequelabs/axe-puppeteer](https://github.com/dequelabs/axe-puppeteer).
 
+This package does not follow Semantic Versioning (SemVer) but instead uses the major and minor version (but not patch version) of axe-core that the package uses. For example, if the API version is v4.7.2, then the axe-core version used by the package will be v4.7.x. The patch version of this package may include bug fixes and new API features but will not introduce breaking changes.
+
 ## Getting Started
 
 Install [Node.js](https://docs.npmjs.com/getting-started/installing-node) if you haven't already.

--- a/packages/webdriverio/README.md
+++ b/packages/webdriverio/README.md
@@ -2,6 +2,8 @@
 
 > Provides a chainable axe API for WebdriverIO and automatically injects into all frames.
 
+This package does not follow Semantic Versioning (SemVer) but instead uses the major and minor version (but not patch version) of axe-core that the package uses. For example, if the API version is v4.7.2, then the axe-core version used by the package will be v4.7.x. The patch version of this package may include bug fixes and new API features but will not introduce breaking changes.
+
 ## Feature Deprecation Notice
 
 Support for `@wdio/sync` is deprecated and testing for it will be removed in a future release.

--- a/packages/webdriverjs/README.md
+++ b/packages/webdriverjs/README.md
@@ -4,6 +4,8 @@
 
 Previous versions of this program were maintained at [dequelabs/axe-webdriverjs](https://github.com/dequelabs/axe-webdriverjs).
 
+This package does not follow Semantic Versioning (SemVer) but instead uses the major and minor version (but not patch version) of axe-core that the package uses. For example, if the API version is v4.7.2, then the axe-core version used by the package will be v4.7.x. The patch version of this package may include bug fixes and new API features but will not introduce breaking changes.
+
 ## Getting Started
 
 Install [Node.js](https://docs.npmjs.com/getting-started/installing-node) if you haven't already.


### PR DESCRIPTION
As per our policy to add a message about how we don't strictly follow semver to our documentation. 

No QA required.