### PR TITLE
chore: replace substr for browser check

### DIFF
--- a/packages/cli/src/lib/utils.ts
+++ b/packages/cli/src/lib/utils.ts
@@ -49,29 +49,28 @@ export const parseBrowser = (browser?: string): string | Error => {
     return 'chrome-headless';
   }
 
-  const l = browser.length;
   switch (browser.toLowerCase()) {
     case 'ff':
-    case 'firefox'.substr(0, l):
-    case 'gecko'.substr(0, l):
-    case 'marionette'.substr(0, l):
+    case 'firefox'.substring(0):
+    case 'gecko'.substring(0):
+    case 'marionette'.substring(0):
       return 'firefox';
 
-    case 'chrome'.substr(0, l):
+    case 'chrome'.substring(0):
       return 'chrome';
 
     case 'ie':
-    case 'explorer'.substr(0, l):
-    case 'internetexplorer'.substr(0, l):
-    case 'internet_explorer'.substr(0, l):
-    case 'internet-explorer'.substr(0, l):
+    case 'explorer'.substring(0):
+    case 'internetexplorer'.substring(0):
+    case 'internet_explorer'.substring(0):
+    case 'internet-explorer'.substring(0):
       return 'ie';
 
-    case 'safari'.substr(0, l):
+    case 'safari'.substring(0):
       return 'safari';
 
-    case 'edge'.substr(0, l):
-    case 'microsoftedge'.substr(0, l):
+    case 'edge'.substring(0):
+    case 'microsoftedge'.substring(0):
       return 'MicrosoftEdge';
 
     default:


### PR DESCRIPTION
Saw this file was using a deprecated API to check for the existence of one string inside of another. Converted it to the newer API for this purpose.

QA shouldn't need to do any manual testing. This is well covered by the unit test which passes.