### PR TITLE
chore: Update timeout on playwright tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -151,7 +151,7 @@ jobs:
       matrix:
         node: [18, 20, 22]
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     needs: lint
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The latest runs of playwright 18 node test [timed out after 15mins](https://github.com/dequelabs/axe-core-npm/actions/runs/17102920148/job/48527777041?pr=1196) before it completed. A 3rd run [took 14 mins](https://github.com/dequelabs/axe-core-npm/actions/runs/17102920148/job/48528901298?pr=1196). Since a completed run is so close to the timeout, decided to increase the timeout to avoid failures.