### PR TITLE
ci(puppeteer): upgrade runner for puppeteer tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         node: [18, 20, 22]
-    runs-on: ubuntu-latest
+    runs-on: deque-ubuntu-latest-4core
     timeout-minutes: 15
     needs: lint
     steps:


### PR DESCRIPTION
Hoping this fixes the constant puppeteer failures for prs as they are timing out when navigating or closing the browser. Note that I'm only updating the runner for puppeteer and no others.

No QA required