### PR TITLE
chore: fix build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint .",
     "prepare": "husky install",
     "precommit": "lint-staged",
-    "build": "npm run --workspaces build"
+    "build": "npm run --workspaces build --if-present"
   },
   "devDependencies": {
     "axe-test-fixtures": "github:dequelabs/axe-test-fixtures#v1",

--- a/test/axe-core/package.json
+++ b/test/axe-core/package.json
@@ -3,8 +3,7 @@
   "private": true,
   "description": "Validate axe-core version with package version",
   "scripts": {
-    "test": "mocha *.test.js",
-    "build": "echo \"No build required, skipping...\""
+    "test": "mocha *.test.js"
   },
   "devDependencies": {
     "glob": "^11.0.0",

--- a/test/wdio/package.json
+++ b/test/wdio/package.json
@@ -3,8 +3,7 @@
   "version": "4.11.0",
   "description": "Tests to ensure @wdio/globals works with @axe-core/webdriverio",
   "scripts": {
-    "test": "wdio run ./wdio.conf.ts",
-    "build": "echo \"Empty build script for deploy pipeline\""
+    "test": "wdio run ./wdio.conf.ts"
   },
   "private": true,
   "devDependencies": {


### PR DESCRIPTION
Only run build scripts if present in the workspaces. For the test workspaces that don't need a build, this removes those that are defined as just empty echos.

Fixes: #1238 