### PR TITLE
fix: reorder exports to place types first

### DIFF
--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -31,9 +31,9 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     }
   },
   "publishConfig": {

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -11,9 +11,9 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -20,9 +20,9 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     }
   },
   "scripts": {

--- a/packages/webdriverjs/package.json
+++ b/packages/webdriverjs/package.json
@@ -40,9 +40,9 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
  Move the "types" condition to the first position in package.json
  exports field to align with Node.js conditional exports standards.
  This ensures TypeScript properly resolves type definitions.

Closes:  #1243