### PR TITLE
chore: bump jsonld from 8.3.3 to 9.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -120,6 +120,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2151,6 +2152,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2174,22 +2176,36 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@digitalbazaar/http-client": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@digitalbazaar/http-client/-/http-client-3.4.1.tgz",
-      "integrity": "sha512-Ahk1N+s7urkgj7WvvUND5f8GiWEPfUw0D41hdElaqLgu8wZScI8gdI0q+qWw5N1d35x7GCRH2uk9mi+Uzo9M3g==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/http-client/-/http-client-4.3.0.tgz",
+      "integrity": "sha512-6lMpxpt9BOmqHKGs9Xm6DP4LlZTBFer/ZjHvP3FcW3IaUWYIWC7dw5RFZnvw4fP57kAVcm1dp3IF+Y50qhBvAw==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "ky": "^0.33.3",
-        "ky-universal": "^0.11.0",
-        "undici": "^5.21.2"
+        "ky": "^1.14.2",
+        "undici": "^6.23.0"
       },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/@digitalbazaar/http-client/node_modules/ky": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-1.14.3.tgz",
+      "integrity": "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/ky?sponsor=1"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2806,15 +2822,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
-      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@humanfs/core": {
@@ -4323,6 +4330,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5590,6 +5598,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -6920,6 +6929,7 @@
       "integrity": "sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.51.0",
         "@typescript-eslint/types": "8.51.0",
@@ -7844,6 +7854,7 @@
       "integrity": "sha512-i38o7wlipLllNrk2hzdDfAmk6nrqm3lR2MtAgWgtHbwznZAKkB84KpkNFfmUXw5Kg3iP1zKlSjwZpKqenuLc+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.20.0"
       },
@@ -7914,6 +7925,7 @@
       "integrity": "sha512-HdzDrRs+ywAqbXGKqe1i/bLtCv47plz4TvsHFH3j729OooT5VH38ctFn5aLXgECmiAKDkmH/A6kOq2Zh5DIxww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^5.1.2",
         "loglevel": "^1.6.0",
@@ -8839,6 +8851,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9977,6 +9990,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -10456,10 +10470,14 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/canonicalize": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.8.tgz",
-      "integrity": "sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A==",
-      "dev": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.1.0.tgz",
+      "integrity": "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
+      }
     },
     "node_modules/chai": {
       "version": "4.5.0",
@@ -12631,7 +12649,8 @@
       "version": "0.0.1534754",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1534754.tgz",
       "integrity": "sha512-26T91cV5dbOYnXdJi5qQHoTtUoNEqwkHcAyu/IKtjIAxiEqPMrDiRkDOPWVsGfNZGmlQVHQbZRSjD8sxagWVsQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/devtools/node_modules/@wdio/config": {
       "version": "8.41.0",
@@ -12779,7 +12798,8 @@
       "version": "0.0.1232444",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1232444.tgz",
       "integrity": "sha512-pM27vqEfxSxRkTMnF+XCmxSEb6duO5R+t8A9DEEJgy4Wz2RVanje2mmj99B6A3zv2r/qGfYlOvYznUhuokizmg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/devtools/node_modules/geckodriver": {
       "version": "4.2.1",
@@ -13369,16 +13389,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -13451,6 +13461,7 @@
       "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.11.0.tgz",
       "integrity": "sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "array.prototype.flat": "^1.2.3",
         "cheerio": "^1.0.0-rc.3",
@@ -13656,6 +13667,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -13742,6 +13754,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -13802,6 +13815,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -14100,6 +14114,7 @@
       "integrity": "sha512-jH4qhahRNGPWbCCVcCpLDl/kvFJ1eOzVnrd1K/sG1RhKr6bZsgZQUiOE3bafVqSOfKP+ay8bM/VagP4+XsO9Xw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/snapshot": "^3.2.4",
         "expect": "^30.0.0",
@@ -17850,6 +17865,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -18001,18 +18017,19 @@
       }
     },
     "node_modules/jsonld": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-8.3.3.tgz",
-      "integrity": "sha512-9YcilrF+dLfg9NTEof/mJLMtbdX1RJ8dbWtJgE00cMOIohb1lIyJl710vFiTaiHTl6ZYODJuBd32xFvUhmv3kg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-9.0.0.tgz",
+      "integrity": "sha512-pjMIdkXfC1T2wrX9B9i2uXhGdyCmgec3qgMht+TDj+S0qX3bjWMQUfL7NeqEhuRTi8G5ESzmL9uGlST7nzSEWg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@digitalbazaar/http-client": "^3.4.1",
-        "canonicalize": "^1.0.1",
+        "@digitalbazaar/http-client": "^4.2.0",
+        "canonicalize": "^2.1.0",
         "lru-cache": "^6.0.0",
-        "rdf-canonize": "^3.4.0"
+        "rdf-canonize": "^5.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/jsonld/node_modules/lru-cache": {
@@ -18145,31 +18162,6 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/ky?sponsor=1"
-      }
-    },
-    "node_modules/ky-universal": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/ky-universal/-/ky-universal-0.11.0.tgz",
-      "integrity": "sha512-65KyweaWvk+uKKkCrfAf+xqN2/epw1IJDtlyCPxYffFCMR8u1sp2U65NtWpnozYfZxQ6IUzIlvUcw+hQ82U2Xw==",
-      "dev": true,
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "node-fetch": "^3.2.10"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/ky-universal?sponsor=1"
-      },
-      "peerDependencies": {
-        "ky": ">=0.31.4",
-        "web-streams-polyfill": ">=3.2.1"
-      },
-      "peerDependenciesMeta": {
-        "web-streams-polyfill": {
-          "optional": true
-        }
       }
     },
     "node_modules/lazystream": {
@@ -18502,6 +18494,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -21146,6 +21139,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "0.2.4",
         "@yarnpkg/lockfile": "^1.1.0",
@@ -22789,6 +22783,7 @@
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
       "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -22920,6 +22915,7 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -23189,6 +23185,7 @@
       "integrity": "sha512-Sdpl/zsYOsagZ4ICoZJPGZw8d9gZmK5DcxVal11dXi/1/t2eIXHjCf5NfmhDg5XnG9Nye+yo/LqMzIxie2rHTw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@puppeteer/browsers": "2.11.0",
         "chromium-bidi": "12.0.1",
@@ -23515,15 +23512,16 @@
       }
     },
     "node_modules/rdf-canonize": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-3.4.0.tgz",
-      "integrity": "sha512-fUeWjrkOO0t1rg7B2fdyDTvngj+9RlUyL92vOdiB7c0FPguWVsniIMjEtHH+meLBO9rzkUlUzBVXgWrjI8P9LA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-5.0.0.tgz",
+      "integrity": "sha512-g8OUrgMXAR9ys/ZuJVfBr05sPPoMA7nHIVs8VEvg9QwM5W4GR2qSFEEHjsyHF1eWlBaf8Ev40WNjQFQ+nJTO3w==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "setimmediate": "^1.0.5"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/react": {
@@ -23532,6 +23530,7 @@
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -23546,6 +23545,7 @@
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -25989,6 +25989,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -26907,6 +26908,7 @@
       "integrity": "sha512-yyxBKfORQ7LuRt/BQKBXrpcq59ZvSW0XxwfjAt3w2/8PmdxaFzijtMhTawprSHhpzeM5BgU2hXHG3lklIERZXg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -27298,15 +27300,13 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
+      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
       "dev": true,
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
@@ -27797,16 +27797,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/webdriver/node_modules/undici": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
     "node_modules/webdriver/node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -27820,6 +27810,7 @@
       "integrity": "sha512-sqXZG11hRM9KjqioVPcXCPLIcdJprNM9e+B6JlyacN6ImgC64MQbgs0vtCDLVsSIX7vg+x771lrS/VxXxqlkJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "^20.11.30",
         "@types/sinonjs__fake-timers": "^8.1.5",
@@ -28324,6 +28315,7 @@
       "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -28595,7 +28587,7 @@
       "dependencies": {
         "@axe-core/webdriverjs": "^4.11.1",
         "axe-core": "~4.11.1",
-        "chromedriver": "*",
+        "chromedriver": "latest",
         "colors": "^1.4.0",
         "commander": "^9.4.1",
         "dotenv": "^17.2.2",
@@ -28729,7 +28721,7 @@
         "clone": "^2.1.2",
         "jest": "^30.0.5",
         "jest-environment-jsdom": "^30.1.2",
-        "jsonld": "^8.2.1",
+        "jsonld": "^9.0.0",
         "ts-jest": "^29.0.3",
         "ts-node": "^10.9.1",
         "tsup": "^8.0.1",
@@ -28933,7 +28925,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1400418.tgz",
       "integrity": "sha512-U8j75zDOXF8IP3o0Cgb7K4tFA9uUHEOru2Wx64+EUqL4LNOh9dRe1i8WKR1k3mSpjcCe3aIkTDvEwq0YkI4hfw==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "packages/webdriverio/node_modules/geckodriver": {
       "version": "4.2.1",
@@ -29277,11 +29270,11 @@
       "version": "4.11.1",
       "license": "ISC",
       "dependencies": {
-        "@axe-core/cli": "*",
-        "@axe-core/playwright": "*",
-        "@axe-core/puppeteer": "*",
-        "@axe-core/webdriverio": "*",
-        "@axe-core/webdriverjs": "*",
+        "@axe-core/cli": "latest",
+        "@axe-core/playwright": "latest",
+        "@axe-core/puppeteer": "latest",
+        "@axe-core/webdriverio": "latest",
+        "@axe-core/webdriverjs": "latest",
         "chai": "^4.3.4",
         "execa": "^5.1.1",
         "mocha": "^11.7.5",
@@ -30012,6 +30005,7 @@
         }
       ],
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@bazel/runfiles": "^6.3.1",
         "jszip": "^3.10.1",
@@ -30141,6 +30135,7 @@
       "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-7.40.0.tgz",
       "integrity": "sha512-UswBOjpWwk7ziGi9beZGX/XFrp4m1Ws0ni5HI9mzAkOlpKKKWhnX6i95pWQV6sPF4Urv4RJf8WXayHhTbzXzdA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/aria-query": "^5.0.0",
         "@types/node": "^18.0.0",

--- a/packages/reporter-earl/package.json
+++ b/packages/reporter-earl/package.json
@@ -50,7 +50,7 @@
     "clone": "^2.1.2",
     "jest": "^30.0.5",
     "jest-environment-jsdom": "^30.1.2",
-    "jsonld": "^8.2.1",
+    "jsonld": "^9.0.0",
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "tsup": "^8.0.1",

--- a/packages/reporter-earl/tests/axeReporterEarl.test.ts
+++ b/packages/reporter-earl/tests/axeReporterEarl.test.ts
@@ -1,12 +1,21 @@
-// jsonld depends on @digitalbazaar/http-client, which depends on the undici HTTP client,
-// which depends on TextEncoder ... which however isn't provided by jsdom, see
-// https://github.com/jsdom/jsdom/issues/2524.
-import { TextEncoder, TextDecoder } from 'util';
+// jsonld depends on @digitalbazaar/http-client, which depends on the undici HTTP client, which depends
+// on TextEncoder, TextDecoder, and ReadableStream ... which however isn't provided by jsdom
+// @see https://github.com/jsdom/jsdom/issues/2524
+// @see https://github.com/mswjs/msw/discussions/1934
+import { TextEncoder, TextDecoder } from 'node:util';
+import ReadableStream from 'node:stream/web';
 type Encoder = typeof global.TextEncoder;
 type Decoder = typeof global.TextDecoder;
+type ReadableStream = typeof global.ReadableStream;
 
 global.TextEncoder = TextEncoder as unknown as Encoder;
 global.TextDecoder = TextDecoder as unknown as Decoder;
+global.ReadableStream = ReadableStream as unknown as ReadableStream;
+
+// jsonld depends on @digitalbazaar/rdf-canonize, which depends on setImmedate which jsdom overrides?
+// @see https://github.com/prisma/prisma/issues/8558#issuecomment-2192317371
+import { setImmediate } from 'node:timers';
+global.setImmediate = setImmediate;
 
 import jsonld from 'jsonld';
 import axe from 'axe-core';


### PR DESCRIPTION
Manual upgrade as https://github.com/dequelabs/axe-core-npm/pull/1255 was stuck on couldn't resolve conflicts.

No QA required