### PR TITLE
chore: use nvmrc file for workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           registry-url: 'https://registry.npmjs.org/'
-          node-version: 24
+          node-version-file: .nvmrc
           cache: 'npm'
       - name: Update npm to 11 if needed
         run: |
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           registry-url: 'https://registry.npmjs.org/'
-          node-version: 24
+          node-version-file: .nvmrc
           cache: 'npm'
       - name: Update npm to 11 if needed
         run: |
@@ -98,7 +98,7 @@ jobs:
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           registry-url: 'https://registry.npmjs.org/'
-          node-version: 24
+          node-version-file: .nvmrc
           cache: 'npm'
       - name: Update npm to 11 if needed
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version-file: .nvmrc
           cache: 'npm'
       - run: npm ci
       - run: npm run lint
@@ -177,7 +177,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version-file: .nvmrc
           cache: 'npm'
       - run: npm ci
       - run: npm test --workspace=test/axe-core

--- a/.github/workflows/update-axe-core.yml
+++ b/.github/workflows/update-axe-core.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version-file: .nvmrc
       - uses: dequelabs/axe-api-team-public/.github/actions/create-update-axe-core-pull-request-v1@main
         with:
           token: ${{ secrets.PAT }}


### PR DESCRIPTION
Moving to use the nvmrc file rather than hard code node version in the workflows.

No QA required