### PR TITLE
refactor(wdio): unlink browser type from global namespace

### DIFF
--- a/packages/webdriverio/src/index.ts
+++ b/packages/webdriverio/src/index.ts
@@ -217,9 +217,11 @@ export default class AxeBuilder {
       await configureAllowedOrigins(this.client);
     }
 
-    const frames = (await this.client.$$(this.frameSelector())) || [];
-    const iframes =
-      frames.concat(await this.client.$$(this.iframeSelector())) || [];
+    const frames = [...((await this.client.$$(this.frameSelector())) || [])];
+    const iframes = [
+      ...frames,
+      ...((await this.client.$$(this.iframeSelector())) || [])
+    ];
     if (!iframes.length) {
       return;
     }

--- a/packages/webdriverio/src/index.ts
+++ b/packages/webdriverio/src/index.ts
@@ -253,7 +253,7 @@ export default class AxeBuilder {
     // ensure we fail quickly if an iframe cannot be loaded (instead of waiting
     // the default length of 30 seconds)
     const { pageLoad } = await this.client.getTimeouts();
-    (this.client as unknown as WebdriverIO.Browser).setTimeout({
+    this.client.setTimeout({
       pageLoad: FRAME_LOAD_TIMEOUT
     });
 
@@ -261,7 +261,7 @@ export default class AxeBuilder {
     try {
       partials = await this.runPartialRecursive(context);
     } finally {
-      (this.client as unknown as WebdriverIO.Browser).setTimeout({
+      this.client.setTimeout({
         pageLoad
       });
     }
@@ -369,7 +369,7 @@ export default class AxeBuilder {
 
     try {
       await client.switchToWindow(newWindow.handle);
-      await (client as unknown as WebdriverIO.Browser).url('data:text/html,');
+      await client.url('data:text/html,');
     } catch (error) {
       throw new Error(
         `switchToWindow failed. Are you using updated browser drivers? \nDriver reported:\n${
@@ -388,3 +388,4 @@ export default class AxeBuilder {
 }
 
 export { AxeBuilder };
+export { WdioBrowser, WdioElement };

--- a/packages/webdriverio/src/index.ts
+++ b/packages/webdriverio/src/index.ts
@@ -253,7 +253,7 @@ export default class AxeBuilder {
     // ensure we fail quickly if an iframe cannot be loaded (instead of waiting
     // the default length of 30 seconds)
     const { pageLoad } = await this.client.getTimeouts();
-    (this.client as WebdriverIO.Browser).setTimeout({
+    (this.client as unknown as WebdriverIO.Browser).setTimeout({
       pageLoad: FRAME_LOAD_TIMEOUT
     });
 
@@ -261,7 +261,7 @@ export default class AxeBuilder {
     try {
       partials = await this.runPartialRecursive(context);
     } finally {
-      (this.client as WebdriverIO.Browser).setTimeout({
+      (this.client as unknown as WebdriverIO.Browser).setTimeout({
         pageLoad
       });
     }
@@ -369,7 +369,7 @@ export default class AxeBuilder {
 
     try {
       await client.switchToWindow(newWindow.handle);
-      await (client as WebdriverIO.Browser).url('data:text/html,');
+      await (client as unknown as WebdriverIO.Browser).url('data:text/html,');
     } catch (error) {
       throw new Error(
         `switchToWindow failed. Are you using updated browser drivers? \nDriver reported:\n${

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -2,6 +2,10 @@ import type { AxeResults, BaseSelector } from 'axe-core';
 import * as axe from 'axe-core';
 import { type Element } from 'webdriverio';
 
+export type WdioElement = {
+  isExisting(): Promise<boolean>;
+};
+
 export interface WdioBrowserLegacy {
   $$(
     selector: string | ((...args: unknown[]) => unknown)
@@ -117,8 +121,6 @@ export interface WdioBrowserV8 {
 }
 
 export type WdioBrowser = WdioBrowserLegacy | WdioBrowserV8;
-
-export type WdioElement = Element | WebdriverIO.Element;
 
 export type CallbackFunction = (
   error: string | null,

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -1,5 +1,6 @@
 import type { AxeResults, BaseSelector } from 'axe-core';
 import * as axe from 'axe-core';
+// eslint-disable-next-line  @typescript-eslint/no-unused-vars
 import { type Element } from 'webdriverio';
 
 export type WdioElement = {
@@ -9,11 +10,9 @@ export type WdioElement = {
 export interface WdioBrowserLegacy {
   $$(
     selector: string | ((...args: unknown[]) => unknown)
-  ): Promise<WebdriverIO.Element[]>;
+  ): Promise<WdioElement[]>;
 
-  $(
-    selector: string | ((...args: unknown[]) => unknown)
-  ): Promise<WebdriverIO.Element>;
+  $(selector: string | ((...args: unknown[]) => unknown)): Promise<WdioElement>;
 
   execute<T = unknown>(
     script: string | ((...args: unknown[]) => T),
@@ -62,13 +61,13 @@ export interface WdioBrowserV8 {
       | string
       | ((...args: unknown[]) => unknown)
       | object
-      | WebdriverIO.Element[]
+      | WdioElement[]
       | HTMLElement[]
   ): Promise<WebdriverIO.ElementArray>;
 
   $(
     selector: string | ((...args: unknown[]) => unknown) | object
-  ): Promise<WebdriverIO.Element>;
+  ): Promise<WdioElement>;
 
   execute<T = unknown>(
     script: string | ((...args: unknown[]) => T),

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -1,33 +1,122 @@
 import type { AxeResults, BaseSelector } from 'axe-core';
 import * as axe from 'axe-core';
-import { type Browser, type Element } from 'webdriverio';
+import { type Element } from 'webdriverio';
 
-/*
-  This type allows both webdriverio v8 and <=v7 Browser types
-  to work in the same codebase. The types are incompatible with
-  each other, but are compatible with the functions that we use.
-  Every new feature that we use from the Browser type will need
-  to be added to the Pick list
-*/
-export type WdioBrowser =
-  | Browser
-  | Pick<
-      WebdriverIO.Browser,
-      | '$$'
-      | '$'
-      | 'switchToFrame'
-      | 'switchToParentFrame'
-      | 'getWindowHandles'
-      | 'getWindowHandle'
-      | 'switchToWindow'
-      | 'createWindow'
-      | 'url'
-      | 'getTimeouts'
-      | 'setTimeout'
-      | 'closeWindow'
-      | 'executeAsync'
-      | 'execute'
-    >;
+export interface WdioBrowserLegacy {
+  $$(
+    selector: string | ((...args: unknown[]) => unknown)
+  ): Promise<WebdriverIO.Element[]>;
+
+  $(
+    selector: string | ((...args: unknown[]) => unknown)
+  ): Promise<WebdriverIO.Element>;
+
+  execute<T = unknown>(
+    script: string | ((...args: unknown[]) => T),
+    ...args: unknown[]
+  ): Promise<T>;
+
+  executeAsync<T = unknown>(
+    script: string | ((...args: unknown[]) => void),
+    ...args: unknown[]
+  ): Promise<T>;
+
+  getTimeouts(): Promise<{
+    implicit?: number;
+    pageLoad?: number;
+    script?: number;
+  }>;
+
+  setTimeout(timeouts: {
+    implicit?: number;
+    pageLoad?: number;
+    script?: number;
+  }): Promise<void>;
+
+  url(url: string): Promise<void>;
+
+  getWindowHandles(): Promise<string[]>;
+
+  getWindowHandle(): Promise<string>;
+
+  createWindow(
+    type: 'tab' | 'window'
+  ): Promise<{ handle: string; type: string }>;
+
+  closeWindow(): Promise<void>;
+
+  switchToFrame(id: number | object | null): Promise<void>;
+
+  switchToParentFrame(): Promise<void>;
+
+  switchToWindow(handle: string): Promise<void>;
+}
+
+export interface WdioBrowserV8 {
+  $$(
+    selector:
+      | string
+      | ((...args: unknown[]) => unknown)
+      | object
+      | WebdriverIO.Element[]
+      | HTMLElement[]
+  ): Promise<WebdriverIO.ElementArray>;
+
+  $(
+    selector: string | ((...args: unknown[]) => unknown) | object
+  ): Promise<WebdriverIO.Element>;
+
+  execute<T = unknown>(
+    script: string | ((...args: unknown[]) => T),
+    ...args: unknown[]
+  ): Promise<T>;
+
+  executeAsync<T = unknown>(
+    script: string | ((...args: unknown[]) => void),
+    ...args: unknown[]
+  ): Promise<T>;
+
+  getTimeouts(): Promise<{
+    implicit?: number;
+    pageLoad?: number;
+    script?: number;
+  }>;
+
+  setTimeout(timeouts: {
+    implicit?: number;
+    pageLoad?: number;
+    script?: number;
+  }): Promise<void>;
+
+  url(
+    path: string,
+    options?: {
+      wait?: 'none' | 'interactive' | 'networkIdle' | 'complete';
+      headers?: Record<string, string>;
+      auth?: { user: string; pass: string };
+      timeout?: number;
+      onBeforeLoad?: () => unknown;
+    }
+  ): Promise<unknown>;
+
+  getWindowHandles(): Promise<string[]>;
+
+  getWindowHandle(): Promise<string>;
+
+  createWindow(
+    type: 'tab' | 'window'
+  ): Promise<{ handle: string; type: string }>;
+
+  closeWindow(): Promise<void>;
+
+  switchToFrame(id: number | object | null): Promise<void>;
+
+  switchToParentFrame(): Promise<void>;
+
+  switchToWindow(handle: string): Promise<void>;
+}
+
+export type WdioBrowser = WdioBrowserLegacy | WdioBrowserV8;
 
 export type WdioElement = Element | WebdriverIO.Element;
 

--- a/packages/webdriverio/src/utils.ts
+++ b/packages/webdriverio/src/utils.ts
@@ -89,7 +89,7 @@ export const axeSourceInject = async (
   return promisify(
     // Had to use executeAsync() because we could not use multiline statements in client.execute()
     // we were able to return a single boolean in a line but not when assigned to a variable.
-    (client as unknown as WebdriverIO.Browser).executeAsync(`
+    client.executeAsync(`
       var callback = arguments[arguments.length - 1];
       ${axeSource};
       window.axe.configure({
@@ -119,11 +119,9 @@ async function assertFrameReady(client: WdioBrowser): Promise<void> {
         reject();
       }, FRAME_LOAD_TIMEOUT);
     });
-    const executePromise = (client as unknown as WebdriverIO.Browser).execute(
-      () => {
-        return document.readyState === 'complete';
-      }
-    );
+    const executePromise = client.execute(() => {
+      return document.readyState === 'complete';
+    });
     const readyState = await Promise.race([timeoutPromise, executePromise]);
     assert(readyState);
   } catch {
@@ -137,7 +135,7 @@ export const axeRunPartial = (
   options?: RunOptions
 ): Promise<PartialResult> => {
   return promisify(
-    (client as unknown as WebdriverIO.Browser)
+    client
       .executeAsync(
         `
       var callback = arguments[arguments.length - 1];
@@ -160,7 +158,7 @@ export const axeGetFrameContext = (
   return promisify(
     // Had to use executeAsync() because we could not use multiline statements in client.execute()
     // we were able to return a single boolean in a line but not when assigned to a variable.
-    (client as unknown as WebdriverIO.Browser).executeAsync(`
+    client.executeAsync(`
       var callback = arguments[arguments.length - 1];
       var context = ${JSON.stringify(context)};
       var frameContexts = window.axe.utils.getFrameContexts(context);
@@ -176,7 +174,7 @@ export const axeRunLegacy = (
   config?: Spec
 ): Promise<AxeResults> => {
   return promisify(
-    (client as unknown as WebdriverIO.Browser)
+    client
       .executeAsync(
         `var callback = arguments[arguments.length - 1];
       var context = ${JSON.stringify(context)} || document;
@@ -209,7 +207,7 @@ export const axeFinishRun = (
   function chunkResults(result: string): Promise<void> {
     const chunk = JSON.stringify(result.substring(0, sizeLimit));
     return promisify(
-      (client as unknown as WebdriverIO.Browser).execute(
+      client.execute(
         `
         window.partialResults ??= '';
         window.partialResults += ${chunk};
@@ -226,7 +224,7 @@ export const axeFinishRun = (
   return chunkResults(partialString)
     .then(() => {
       return promisify(
-        (client as unknown as WebdriverIO.Browser).executeAsync(
+        client.executeAsync(
           `var callback = arguments[arguments.length - 1];
       ${axeSource};
       window.axe.configure({
@@ -246,7 +244,7 @@ export const axeFinishRun = (
 
 export const configureAllowedOrigins = (client: WdioBrowser): Promise<void> => {
   return promisify(
-    (client as unknown as WebdriverIO.Browser).execute(`
+    client.execute(`
       window.axe.configure({ allowedOrigins: ['<unsafe_all_origins>'] })
     `)
   );

--- a/packages/webdriverio/src/utils.ts
+++ b/packages/webdriverio/src/utils.ts
@@ -89,7 +89,7 @@ export const axeSourceInject = async (
   return promisify(
     // Had to use executeAsync() because we could not use multiline statements in client.execute()
     // we were able to return a single boolean in a line but not when assigned to a variable.
-    (client as WebdriverIO.Browser).executeAsync(`
+    (client as unknown as WebdriverIO.Browser).executeAsync(`
       var callback = arguments[arguments.length - 1];
       ${axeSource};
       window.axe.configure({
@@ -119,9 +119,11 @@ async function assertFrameReady(client: WdioBrowser): Promise<void> {
         reject();
       }, FRAME_LOAD_TIMEOUT);
     });
-    const executePromise = (client as WebdriverIO.Browser).execute(() => {
-      return document.readyState === 'complete';
-    });
+    const executePromise = (client as unknown as WebdriverIO.Browser).execute(
+      () => {
+        return document.readyState === 'complete';
+      }
+    );
     const readyState = await Promise.race([timeoutPromise, executePromise]);
     assert(readyState);
   } catch {
@@ -135,7 +137,7 @@ export const axeRunPartial = (
   options?: RunOptions
 ): Promise<PartialResult> => {
   return promisify(
-    (client as WebdriverIO.Browser)
+    (client as unknown as WebdriverIO.Browser)
       .executeAsync(
         `
       var callback = arguments[arguments.length - 1];
@@ -158,7 +160,7 @@ export const axeGetFrameContext = (
   return promisify(
     // Had to use executeAsync() because we could not use multiline statements in client.execute()
     // we were able to return a single boolean in a line but not when assigned to a variable.
-    (client as WebdriverIO.Browser).executeAsync(`
+    (client as unknown as WebdriverIO.Browser).executeAsync(`
       var callback = arguments[arguments.length - 1];
       var context = ${JSON.stringify(context)};
       var frameContexts = window.axe.utils.getFrameContexts(context);
@@ -174,7 +176,7 @@ export const axeRunLegacy = (
   config?: Spec
 ): Promise<AxeResults> => {
   return promisify(
-    (client as WebdriverIO.Browser)
+    (client as unknown as WebdriverIO.Browser)
       .executeAsync(
         `var callback = arguments[arguments.length - 1];
       var context = ${JSON.stringify(context)} || document;
@@ -207,7 +209,7 @@ export const axeFinishRun = (
   function chunkResults(result: string): Promise<void> {
     const chunk = JSON.stringify(result.substring(0, sizeLimit));
     return promisify(
-      (client as WebdriverIO.Browser).execute(
+      (client as unknown as WebdriverIO.Browser).execute(
         `
         window.partialResults ??= '';
         window.partialResults += ${chunk};
@@ -224,7 +226,7 @@ export const axeFinishRun = (
   return chunkResults(partialString)
     .then(() => {
       return promisify(
-        (client as WebdriverIO.Browser).executeAsync(
+        (client as unknown as WebdriverIO.Browser).executeAsync(
           `var callback = arguments[arguments.length - 1];
       ${axeSource};
       window.axe.configure({
@@ -244,7 +246,7 @@ export const axeFinishRun = (
 
 export const configureAllowedOrigins = (client: WdioBrowser): Promise<void> => {
   return promisify(
-    (client as WebdriverIO.Browser).execute(`
+    (client as unknown as WebdriverIO.Browser).execute(`
       window.axe.configure({ allowedOrigins: ['<unsafe_all_origins>'] })
     `)
   );


### PR DESCRIPTION
Deatches the Browser type from the global namespace and separates them by versions we support. This is a precursor to supporting v9 types which https://github.com/dequelabs/axe-core-npm/pull/1302 tried but failed to get the types correct. Am trying the same thing but without the conversion to v9 for now.

No QA required