### PR TITLE
ci: replace browser-driver-manager with browser-actions/setup-chrome

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
           node-version: ${{ matrix.node}}
           cache: 'npm'
       - run: npm ci
-      - uses: browser-actions/setup-chrome@v1
+      - uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2.1.2
         id: setup-chrome
         with:
           chrome-version: ${{ vars.CHROME_VERSION || 'stable' }}
@@ -61,7 +61,7 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: 'npm'
       - run: npm ci
-      - uses: browser-actions/setup-chrome@v1
+      - uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2.1.2
         id: setup-chrome
         with:
           chrome-version: ${{ vars.CHROME_VERSION || 'stable' }}
@@ -84,7 +84,7 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: 'npm'
       - run: npm ci
-      - uses: browser-actions/setup-chrome@v1
+      - uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2.1.2
         id: setup-chrome
         with:
           chrome-version: ${{ vars.CHROME_VERSION || 'stable' }}
@@ -109,7 +109,7 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: 'npm'
       - run: npm ci
-      - uses: browser-actions/setup-chrome@v1
+      - uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2.1.2
         id: setup-chrome
         with:
           chrome-version: ${{ vars.CHROME_VERSION || 'stable' }}
@@ -169,7 +169,7 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: 'npm'
       - run: npm ci
-      - uses: browser-actions/setup-chrome@v1
+      - uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2.1.2
         id: setup-chrome
         with:
           chrome-version: ${{ vars.CHROME_VERSION || 'stable' }}
@@ -194,7 +194,7 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: 'npm'
       - run: npm ci
-      - uses: browser-actions/setup-chrome@v1
+      - uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2.1.2
         id: setup-chrome
         with:
           chrome-version: ${{ vars.CHROME_VERSION || 'stable' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,10 +36,15 @@ jobs:
           node-version: ${{ matrix.node}}
           cache: 'npm'
       - run: npm ci
-      # HACK: Force a TTY to enable browser-driver-manager to manipulate stdout.
-      - shell: 'script -q -e -c "bash {0}"'
-        run: npx browser-driver-manager install chrome@145
-        working-directory: packages/puppeteer
+      - uses: browser-actions/setup-chrome@v1
+        id: setup-chrome
+        with:
+          chrome-version: ${{ vars.CHROME_VERSION || 'latest' }}
+          install-chromedriver: true
+          install-dependencies: true
+      - run: |
+          echo "CHROME_TEST_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> "$GITHUB_ENV"
+          echo "CHROMEDRIVER_TEST_PATH=${{ steps.setup-chrome.outputs.chromedriver-path }}" >> "$GITHUB_ENV"
       - run: npm run build --workspace=packages/puppeteer
       - run: npm run coverage --workspace=packages/puppeteer
       - run: npm run test:export --workspace=packages/puppeteer
@@ -56,10 +61,15 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: 'npm'
       - run: npm ci
-        # HACK: Force a TTY to enable browser-driver-manager to manipulate stdout.
-      - shell: 'script -q -e -c "bash {0}"'
-        run: npx browser-driver-manager install chrome@145
-        working-directory: packages/cli
+      - uses: browser-actions/setup-chrome@v1
+        id: setup-chrome
+        with:
+          chrome-version: ${{ vars.CHROME_VERSION || 'latest' }}
+          install-chromedriver: true
+          install-dependencies: true
+      - run: |
+          echo "CHROME_TEST_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> "$GITHUB_ENV"
+          echo "CHROMEDRIVER_TEST_PATH=${{ steps.setup-chrome.outputs.chromedriver-path }}" >> "$GITHUB_ENV"
       - run: npm run coverage --workspace=packages/cli
 
   webdriverjs:
@@ -74,10 +84,15 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: 'npm'
       - run: npm ci
-      # HACK: Force a TTY to enable browser-driver-manager to manipulate stdout.
-      - shell: 'script -q -e -c "bash {0}"'
-        run: npx browser-driver-manager install chrome@145
-        working-directory: packages/webdriverjs
+      - uses: browser-actions/setup-chrome@v1
+        id: setup-chrome
+        with:
+          chrome-version: ${{ vars.CHROME_VERSION || 'latest' }}
+          install-chromedriver: true
+          install-dependencies: true
+      - run: |
+          echo "CHROME_TEST_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> "$GITHUB_ENV"
+          echo "CHROMEDRIVER_TEST_PATH=${{ steps.setup-chrome.outputs.chromedriver-path }}" >> "$GITHUB_ENV"
       - run: npm run build --workspace=packages/webdriverjs
       - run: npm run coverage --workspace=packages/webdriverjs
       - run: npm run test:export --workspace=packages/webdriverjs
@@ -94,10 +109,15 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: 'npm'
       - run: npm ci
-      # HACK: Force a TTY to enable browser-driver-manager to manipulate stdout.
-      - shell: 'script -q -e -c "bash {0}"'
-        run: npx browser-driver-manager install chrome@145
-        working-directory: packages/webdriverio
+      - uses: browser-actions/setup-chrome@v1
+        id: setup-chrome
+        with:
+          chrome-version: ${{ vars.CHROME_VERSION || 'latest' }}
+          install-chromedriver: true
+          install-dependencies: true
+      - run: |
+          echo "CHROME_TEST_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> "$GITHUB_ENV"
+          echo "CHROMEDRIVER_TEST_PATH=${{ steps.setup-chrome.outputs.chromedriver-path }}" >> "$GITHUB_ENV"
       - run: npm run build --workspace=packages/webdriverio
       - run: npm run coverage --workspace=packages/webdriverio
       - run: npm run test:export --workspace=packages/webdriverio
@@ -149,7 +169,15 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: 'npm'
       - run: npm ci
-      - run: npx playwright install --with-deps
+      - uses: browser-actions/setup-chrome@v1
+        id: setup-chrome
+        with:
+          chrome-version: ${{ vars.CHROME_VERSION || 'latest' }}
+          install-chromedriver: true
+          install-dependencies: true
+      - run: |
+          echo "CHROME_TEST_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> "$GITHUB_ENV"
+          echo "CHROMEDRIVER_TEST_PATH=${{ steps.setup-chrome.outputs.chromedriver-path }}" >> "$GITHUB_ENV"
       - run: npm run build --workspace=packages/playwright
       - run: npm run coverage --workspace=packages/playwright
       - run: npm run test:export --workspace=packages/playwright
@@ -166,6 +194,15 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: 'npm'
       - run: npm ci
+      - uses: browser-actions/setup-chrome@v1
+        id: setup-chrome
+        with:
+          chrome-version: ${{ vars.CHROME_VERSION || 'latest' }}
+          install-chromedriver: true
+          install-dependencies: true
+      - run: |
+          echo "CHROME_TEST_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> "$GITHUB_ENV"
+          echo "CHROMEDRIVER_TEST_PATH=${{ steps.setup-chrome.outputs.chromedriver-path }}" >> "$GITHUB_ENV"
       - run: npm run test --workspace=test/wdio
 
   axe_core_test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: browser-actions/setup-chrome@v1
         id: setup-chrome
         with:
-          chrome-version: ${{ vars.CHROME_VERSION || 'latest' }}
+          chrome-version: ${{ vars.CHROME_VERSION || 'stable' }}
           install-chromedriver: true
           install-dependencies: true
       - run: |
@@ -64,7 +64,7 @@ jobs:
       - uses: browser-actions/setup-chrome@v1
         id: setup-chrome
         with:
-          chrome-version: ${{ vars.CHROME_VERSION || 'latest' }}
+          chrome-version: ${{ vars.CHROME_VERSION || 'stable' }}
           install-chromedriver: true
           install-dependencies: true
       - run: |
@@ -87,7 +87,7 @@ jobs:
       - uses: browser-actions/setup-chrome@v1
         id: setup-chrome
         with:
-          chrome-version: ${{ vars.CHROME_VERSION || 'latest' }}
+          chrome-version: ${{ vars.CHROME_VERSION || 'stable' }}
           install-chromedriver: true
           install-dependencies: true
       - run: |
@@ -112,7 +112,7 @@ jobs:
       - uses: browser-actions/setup-chrome@v1
         id: setup-chrome
         with:
-          chrome-version: ${{ vars.CHROME_VERSION || 'latest' }}
+          chrome-version: ${{ vars.CHROME_VERSION || 'stable' }}
           install-chromedriver: true
           install-dependencies: true
       - run: |
@@ -172,7 +172,7 @@ jobs:
       - uses: browser-actions/setup-chrome@v1
         id: setup-chrome
         with:
-          chrome-version: ${{ vars.CHROME_VERSION || 'latest' }}
+          chrome-version: ${{ vars.CHROME_VERSION || 'stable' }}
           install-chromedriver: true
           install-dependencies: true
       - run: |
@@ -197,7 +197,7 @@ jobs:
       - uses: browser-actions/setup-chrome@v1
         id: setup-chrome
         with:
-          chrome-version: ${{ vars.CHROME_VERSION || 'latest' }}
+          chrome-version: ${{ vars.CHROME_VERSION || 'stable' }}
           install-chromedriver: true
           install-dependencies: true
       - run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,6 @@
         "packages/*",
         "test/*"
       ],
-      "dependencies": {
-        "browser-driver-manager": "^2.0.0"
-      },
       "devDependencies": {
         "@types/node": "^25.4.0",
         "axe-test-fixtures": "github:dequelabs/axe-test-fixtures#v1",
@@ -9627,101 +9624,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/browser-driver-manager": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/browser-driver-manager/-/browser-driver-manager-2.0.1.tgz",
-      "integrity": "sha512-G5PAHYmJq5XSd1Gc1odpuECNpDSSPdscTavxfPdK3K+4/FJ5/quM3LyXAEmAL1iu6wytm/8cl8HYU1RfjBKGLg==",
-      "dependencies": {
-        "@puppeteer/browsers": "^2.2.3",
-        "commander": "^10.0.1"
-      },
-      "bin": {
-        "browser-driver-manager": "bin/browser-driver-manager"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/browser-driver-manager/node_modules/@puppeteer/browsers": {
-      "version": "2.10.7",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.7.tgz",
-      "integrity": "sha512-wHWLkQWBjHtajZeqCB74nsa/X70KheyOhySYBRmVQDJiNj0zjZR/naPCvdWjMhcG1LmjaMV/9WtTo5mpe8qWLw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "^4.4.1",
-        "extract-zip": "^2.0.1",
-        "progress": "^2.0.3",
-        "proxy-agent": "^6.5.0",
-        "semver": "^7.7.2",
-        "tar-fs": "^3.1.0",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "browsers": "lib/cjs/main-cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/browser-driver-manager/node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/browser-driver-manager/node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/browser-driver-manager/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/browser-driver-manager/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/browser-driver-manager/node_modules/proxy-agent": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
-      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.6",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.1.0",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/browser-stdout": {
@@ -27348,7 +27250,6 @@
         "chromedriver": "latest",
         "colors": "^1.4.0",
         "commander": "^9.4.1",
-        "dotenv": "^17.2.2",
         "selenium-webdriver": "~4.41.0"
       },
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27250,6 +27250,7 @@
         "chromedriver": "latest",
         "colors": "^1.4.0",
         "commander": "^9.4.1",
+        "dotenv": "^17.2.2",
         "selenium-webdriver": "~4.41.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -52,8 +52,5 @@
     "*.{json,css,md,html}": [
       "prettier --write"
     ]
-  },
-  "dependencies": {
-    "browser-driver-manager": "^2.0.0"
   }
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -14,7 +14,14 @@ Install axe CLI globally: `npm install @axe-core/cli -g`
 
 Lastly, install the webdrivers of the browsers you wish to use. A webdriver is a driver for your web browsers. It allows other programs on your machine to open a browser and operate it.
 
-To install the latest version of Chromedriver globally, install browser-driver-manager: `npm install -g browser-driver-manager`. Then run `npx browser-driver-manager install chrome`.
+To install matched Chrome and ChromeDriver versions, use [`@puppeteer/browsers`](https://pptr.dev/browsers-api):
+
+```
+npx @puppeteer/browsers install chrome@stable
+npx @puppeteer/browsers install chromedriver@stable
+```
+
+Each command prints the resolved binary path. Pass the ChromeDriver path to axe via `--chromedriver-path <path>`.
 
 Current information about other available webdrivers can be found at [selenium-webdriver project](https://www.npmjs.com/package/selenium-webdriver). Alternatively, you could use [Webdriver manager](https://www.npmjs.com/package/webdriver-manager)
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -14,14 +14,18 @@ Install axe CLI globally: `npm install @axe-core/cli -g`
 
 Lastly, install the webdrivers of the browsers you wish to use. A webdriver is a driver for your web browsers. It allows other programs on your machine to open a browser and operate it.
 
-To install matched Chrome and ChromeDriver versions, use [`@puppeteer/browsers`](https://pptr.dev/browsers-api):
+To install matched Chrome and ChromeDriver versions, use [`@puppeteer/browsers`](https://pptr.dev/browsers-api). By default it installs into the current working directory; pass `--path` to keep the binaries in a stable shared location you can reuse across projects (e.g. `~/.cache/puppeteer-browsers`):
 
 ```
-npx @puppeteer/browsers install chrome@stable
-npx @puppeteer/browsers install chromedriver@stable
+npx @puppeteer/browsers install chrome@stable --path ~/.cache/puppeteer-browsers
+npx @puppeteer/browsers install chromedriver@stable --path ~/.cache/puppeteer-browsers
 ```
 
-Each command prints the resolved binary path. Pass the ChromeDriver path to axe via `--chromedriver-path <path>`.
+Each command prints the resolved binary path. Pass **both** to axe so the matched pair is used — if you only pass `--chromedriver-path`, ChromeDriver will fall back to your system-installed Chrome, which is almost never the same version and will fail with `session not created`:
+
+```
+axe www.deque.com --chrome-path <path/to/chrome> --chromedriver-path <path/to/chromedriver>
+```
 
 Current information about other available webdrivers can be found at [selenium-webdriver project](https://www.npmjs.com/package/selenium-webdriver). Alternatively, you could use [Webdriver manager](https://www.npmjs.com/package/webdriver-manager)
 
@@ -183,10 +187,14 @@ To see additional information like test tool name, version and environment detai
 axe www.deque.com --verbose
 ```
 
-## ChromeDriver Path
+## Chrome and ChromeDriver paths
 
-If you need to test your page using an older version of Chrome, you can use `--chromedriver-path` followed by the absolute path to the desired version of the ChromeDriver executable.
+If you need to test against a specific Chrome / ChromeDriver pair (for example, the binaries installed via `@puppeteer/browsers`), pass their absolute paths with `--chrome-path` and `--chromedriver-path`:
 
 ```
-axe www.deque.com --chromedriver-path="absolute/path/to/chromedriver"
+axe www.deque.com \
+  --chrome-path="absolute/path/to/chrome" \
+  --chromedriver-path="absolute/path/to/chromedriver"
 ```
+
+Both flags are required whenever the system-installed Chrome isn't the same version as the ChromeDriver you're pointing at. Without `--chrome-path`, ChromeDriver auto-discovers the system Chrome and fails with `session not created: This version of ChromeDriver only supports Chrome version N`. Passing `--chrome-path` forces the matched binary so the versions agree.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,7 +52,6 @@
     "chromedriver": "latest",
     "colors": "^1.4.0",
     "commander": "^9.4.1",
-    "dotenv": "^17.2.2",
     "selenium-webdriver": "~4.41.0"
   },
   "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,6 +52,7 @@
     "chromedriver": "latest",
     "colors": "^1.4.0",
     "commander": "^9.4.1",
+    "dotenv": "^17.2.2",
     "selenium-webdriver": "~4.41.0"
   },
   "devDependencies": {

--- a/packages/cli/src/bin/index.ts
+++ b/packages/cli/src/bin/index.ts
@@ -131,19 +131,16 @@ const cli = async (
         )
       ) {
         console.error(error('Error: %s'), e.message);
-        console.log(`\nPlease use browser-driver-manager to install matching versions of Chrome and ChromeDriver:
-        
-        $ npx browser-driver-manager install chrome
-        
-        This will install the latest synced versions. You may install specific synced versions using 
-        
-        $ npx browser-driver-manager install chrome@<version>
+        console.log(`\nPlease install matched Chrome and ChromeDriver versions with @puppeteer/browsers:
 
-        where <version> is a specific version, e.g. 123.45.67, or a channel, e.g. canary.
+        $ npx @puppeteer/browsers install chrome@stable
+        $ npx @puppeteer/browsers install chromedriver@stable
 
-        You may also pass the \`--chromedriver-path\` option to axe:
+        Pin a specific version with @<version>, e.g. chrome@123.0.6312.86 or chrome@canary.
 
-        $ axe --chromedriver-path <path/to/chromedriver-executable>`);
+        Each command prints the resolved binary path. Pass them to axe via:
+
+        $ axe --chrome-path <path/to/chrome> --chromedriver-path <path/to/chromedriver>`);
         process.exit(2);
       } else {
         throw e;

--- a/packages/cli/src/bin/index.ts
+++ b/packages/cli/src/bin/index.ts
@@ -131,10 +131,10 @@ const cli = async (
         )
       ) {
         console.error(error('Error: %s'), e.message);
-        console.log(`\nPlease install matched Chrome and ChromeDriver versions with @puppeteer/browsers:
+        console.log(`\nPlease install matched Chrome and ChromeDriver versions with @puppeteer/browsers. Pass --path to keep the binaries in a stable shared location you can reuse across projects:
 
-        $ npx @puppeteer/browsers install chrome@stable
-        $ npx @puppeteer/browsers install chromedriver@stable
+        $ npx @puppeteer/browsers install chrome@stable --path ~/.cache/puppeteer-browsers
+        $ npx @puppeteer/browsers install chromedriver@stable --path ~/.cache/puppeteer-browsers
 
         Pin a specific version with @<version>, e.g. chrome@123.0.6312.86 or chrome@canary.
 

--- a/packages/cli/src/lib/utils.ts
+++ b/packages/cli/src/lib/utils.ts
@@ -2,13 +2,6 @@ import fs from 'fs';
 import path from 'path';
 import colors from 'colors';
 import type { AxeResults, UnlabelledFrameSelector } from 'axe-core';
-import { config } from 'dotenv';
-import os from 'os';
-
-const HOME_DIR = os.homedir();
-const BDM_CACHE_DIR = path.resolve(HOME_DIR, '.browser-driver-manager');
-
-config({ path: path.resolve(BDM_CACHE_DIR, '.env'), quiet: true });
 
 export const { CHROME_TEST_PATH, CHROMEDRIVER_TEST_PATH } = process.env;
 

--- a/packages/cli/src/lib/utils.ts
+++ b/packages/cli/src/lib/utils.ts
@@ -1,7 +1,18 @@
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import colors from 'colors';
+import { config } from 'dotenv';
 import type { AxeResults, UnlabelledFrameSelector } from 'axe-core';
+
+// Legacy compat: previous versions of axe-cli documented `browser-driver-manager`
+// as the install path and auto-loaded the env vars it wrote to
+// `~/.browser-driver-manager/.env`. The recommended install path is now
+// `@puppeteer/browsers` (see README), but we keep this shim so existing BDM
+// users don't silently break. `quiet: true` avoids logging when the file
+// isn't present, and dotenv won't override env vars already in `process.env`.
+const BDM_CACHE_DIR = path.resolve(os.homedir(), '.browser-driver-manager');
+config({ path: path.resolve(BDM_CACHE_DIR, '.env'), quiet: true });
 
 export const { CHROME_TEST_PATH, CHROMEDRIVER_TEST_PATH } = process.env;
 

--- a/packages/cli/src/lib/webdriver.test.ts
+++ b/packages/cli/src/lib/webdriver.test.ts
@@ -17,18 +17,18 @@ describe('startDriver', () => {
       process.env.CHROME_TEST_PATH,
       [
         'CHROME_TEST_PATH is not set.',
-        'Install Chrome: npx @puppeteer/browsers install chrome@stable',
+        'Install Chrome: npx @puppeteer/browsers install chrome@stable --path ~/.cache/puppeteer-browsers',
         'The command prints the resolved binary path; export it as CHROME_TEST_PATH.',
-        'e.g. export CHROME_TEST_PATH="$(npx @puppeteer/browsers install chrome@stable | awk \'{print $2}\')"'
+        'e.g. export CHROME_TEST_PATH="$(npx @puppeteer/browsers install chrome@stable --path ~/.cache/puppeteer-browsers | awk \'{print $2}\')"'
       ].join('\n')
     );
     assert(
       process.env.CHROMEDRIVER_TEST_PATH,
       [
         'CHROMEDRIVER_TEST_PATH is not set.',
-        'Install ChromeDriver: npx @puppeteer/browsers install chromedriver@stable',
+        'Install ChromeDriver: npx @puppeteer/browsers install chromedriver@stable --path ~/.cache/puppeteer-browsers',
         'The command prints the resolved binary path; export it as CHROMEDRIVER_TEST_PATH.',
-        'e.g. export CHROMEDRIVER_TEST_PATH="$(npx @puppeteer/browsers install chromedriver@stable | awk \'{print $2}\')"'
+        'e.g. export CHROMEDRIVER_TEST_PATH="$(npx @puppeteer/browsers install chromedriver@stable --path ~/.cache/puppeteer-browsers | awk \'{print $2}\')"'
       ].join('\n')
     );
   });

--- a/packages/cli/src/lib/webdriver.test.ts
+++ b/packages/cli/src/lib/webdriver.test.ts
@@ -15,11 +15,11 @@ describe('startDriver', () => {
   before(() => {
     assert(
       process.env.CHROME_TEST_PATH,
-      'CHROME_TEST_PATH is not set. Run `npx browser-driver-manager install chrome`'
+      'CHROME_TEST_PATH is not set. Install Chrome and export the path (CI uses browser-actions/setup-chrome).'
     );
     assert(
       process.env.CHROMEDRIVER_TEST_PATH,
-      'CHROMEDRIVER_TEST_PATH is not set. Run `npx browser-driver-manager install chrome`'
+      'CHROMEDRIVER_TEST_PATH is not set. Install ChromeDriver and export the path (CI uses browser-actions/setup-chrome).'
     );
   });
   beforeEach(() => {

--- a/packages/cli/src/lib/webdriver.test.ts
+++ b/packages/cli/src/lib/webdriver.test.ts
@@ -15,11 +15,21 @@ describe('startDriver', () => {
   before(() => {
     assert(
       process.env.CHROME_TEST_PATH,
-      'CHROME_TEST_PATH is not set. Install Chrome and export the path (CI uses browser-actions/setup-chrome).'
+      [
+        'CHROME_TEST_PATH is not set.',
+        'Install Chrome: npx @puppeteer/browsers install chrome@stable',
+        'The command prints the resolved binary path; export it as CHROME_TEST_PATH.',
+        'e.g. export CHROME_TEST_PATH="$(npx @puppeteer/browsers install chrome@stable | awk \'{print $2}\')"'
+      ].join('\n')
     );
     assert(
       process.env.CHROMEDRIVER_TEST_PATH,
-      'CHROMEDRIVER_TEST_PATH is not set. Install ChromeDriver and export the path (CI uses browser-actions/setup-chrome).'
+      [
+        'CHROMEDRIVER_TEST_PATH is not set.',
+        'Install ChromeDriver: npx @puppeteer/browsers install chromedriver@stable',
+        'The command prints the resolved binary path; export it as CHROMEDRIVER_TEST_PATH.',
+        'e.g. export CHROMEDRIVER_TEST_PATH="$(npx @puppeteer/browsers install chromedriver@stable | awk \'{print $2}\')"'
+      ].join('\n')
     );
   });
   beforeEach(() => {

--- a/packages/playwright/test/axe-playwright.spec.ts
+++ b/packages/playwright/test/axe-playwright.spec.ts
@@ -50,9 +50,9 @@ describe('@axe-core/playwright', () => {
   beforeEach(async () => {
     browser = await chromium.launch({
       args: ['--disable-dev-shm-usage'],
-      ...(process.env.CHROME_TEST_PATH && {
-        executablePath: process.env.CHROME_TEST_PATH
-      })
+      ...(process.env.CHROME_TEST_PATH
+        ? { executablePath: process.env.CHROME_TEST_PATH }
+        : {})
     });
     const context = await browser.newContext();
     page = await context.newPage();

--- a/packages/playwright/test/axe-playwright.spec.ts
+++ b/packages/playwright/test/axe-playwright.spec.ts
@@ -49,7 +49,10 @@ describe('@axe-core/playwright', () => {
 
   beforeEach(async () => {
     browser = await chromium.launch({
-      args: ['--disable-dev-shm-usage']
+      args: ['--disable-dev-shm-usage'],
+      ...(process.env.CHROME_TEST_PATH && {
+        executablePath: process.env.CHROME_TEST_PATH
+      })
     });
     const context = await browser.newContext();
     page = await context.newPage();

--- a/packages/puppeteer/test/esmTest.mjs
+++ b/packages/puppeteer/test/esmTest.mjs
@@ -19,7 +19,10 @@ const options = {};
 if (process.env.CI) {
   options.args = [];
   options.args.push('--no-sandbox', '--disable-setuid-sandbox');
-  options.executablePath = '/usr/bin/google-chrome-stable';
+}
+
+if (process.env.CHROME_TEST_PATH) {
+  options.executablePath = process.env.CHROME_TEST_PATH;
 }
 
 async function integrationTest() {

--- a/packages/puppeteer/test/utils.ts
+++ b/packages/puppeteer/test/utils.ts
@@ -44,5 +44,9 @@ export function puppeteerOpts(): LaunchOptions {
     options.args.push('--no-sandbox', '--disable-setuid-sandbox');
   }
 
+  if (process.env.CHROME_TEST_PATH) {
+    options.executablePath = process.env.CHROME_TEST_PATH;
+  }
+
   return options;
 }

--- a/packages/webdriverio/README.md
+++ b/packages/webdriverio/README.md
@@ -20,12 +20,14 @@ Install [Node.js](https://docs.npmjs.com/getting-started/installing-node) if you
 
 > Download and install any necessary browser drivers on your machine's PATH. [More on WebdriverIO setup](https://v6.webdriver.io/docs/gettingstarted.html#taking-the-first-step).
 
-To install matched Chrome and ChromeDriver versions, use [`@puppeteer/browsers`](https://pptr.dev/browsers-api):
+To install matched Chrome and ChromeDriver versions, use [`@puppeteer/browsers`](https://pptr.dev/browsers-api). By default it installs into the current working directory; pass `--path` to keep the binaries in a stable shared location you can reuse across projects (e.g. `~/.cache/puppeteer-browsers`):
 
 ```
-npx @puppeteer/browsers install chrome@stable
-npx @puppeteer/browsers install chromedriver@stable
+npx @puppeteer/browsers install chrome@stable --path ~/.cache/puppeteer-browsers
+npx @puppeteer/browsers install chromedriver@stable --path ~/.cache/puppeteer-browsers
 ```
+
+Each command prints the resolved binary path. Wire **both** into your WebdriverIO setup — point the Chrome binary via the `goog:chromeOptions.binary` capability, and run/point at the matching ChromeDriver via your chromedriver service (e.g. `@wdio/chromedriver-service` with `chromedriverCustomPath`). If you only point at the new ChromeDriver and let it auto-discover Chrome, it will fall back to your system-installed Chrome — almost never the same version — and fail with `session not created`.
 
 Install WebdriverIO: `npm install webdriverio`
 

--- a/packages/webdriverio/README.md
+++ b/packages/webdriverio/README.md
@@ -20,7 +20,12 @@ Install [Node.js](https://docs.npmjs.com/getting-started/installing-node) if you
 
 > Download and install any necessary browser drivers on your machine's PATH. [More on WebdriverIO setup](https://v6.webdriver.io/docs/gettingstarted.html#taking-the-first-step).
 
-To install the latest version of Chromedriver globally, install browser-driver-manager: `npm install -g browser-driver-manager`. Then run `npx browser-driver-manager install chrome`.
+To install matched Chrome and ChromeDriver versions, use [`@puppeteer/browsers`](https://pptr.dev/browsers-api):
+
+```
+npx @puppeteer/browsers install chrome@stable
+npx @puppeteer/browsers install chromedriver@stable
+```
 
 Install WebdriverIO: `npm install webdriverio`
 

--- a/packages/webdriverio/error-handling.md
+++ b/packages/webdriverio/error-handling.md
@@ -10,7 +10,14 @@ Version 4.3.0 and above of the axe-core integrations use a new technique when ca
 
 ### Having an Out-of-date Driver
 
-A common problem is having an out-of-date driver. To fix this issue make sure that your local install of [geckodriver](https://github.com/mozilla/geckodriver/releases) or [chromedriver](https://chromedriver.chromium.org/downloads) is up-to-date.
+A common problem is having an out-of-date driver, or — more often — a driver whose version doesn't match the browser it's driving. To fix this, install a matched Chrome / ChromeDriver pair with [`@puppeteer/browsers`](https://pptr.dev/browsers-api) and point your WebdriverIO setup at **both** binaries:
+
+```
+npx @puppeteer/browsers install chrome@stable --path ~/.cache/puppeteer-browsers
+npx @puppeteer/browsers install chromedriver@stable --path ~/.cache/puppeteer-browsers
+```
+
+Pass the printed Chrome path via the `goog:chromeOptions.binary` capability and run the printed ChromeDriver via your chromedriver service (e.g. `@wdio/chromedriver-service` with `chromedriverCustomPath`). If you only point at the new ChromeDriver and let it auto-discover Chrome, it will fall back to your system Chrome — which almost never matches — and fail with `session not created`. For Firefox, make sure your local install of [geckodriver](https://github.com/mozilla/geckodriver/releases) is up-to-date.
 
 An example error message for this problem will include a message about `switchToWindow`.
 

--- a/packages/webdriverio/test/axe-webdriverio.spec.ts
+++ b/packages/webdriverio/test/axe-webdriverio.spec.ts
@@ -51,18 +51,18 @@ describe('@axe-core/webdriverio', () => {
           process.env.CHROME_TEST_PATH,
           [
             'CHROME_TEST_PATH is not set.',
-            'Install Chrome: npx @puppeteer/browsers install chrome@stable',
+            'Install Chrome: npx @puppeteer/browsers install chrome@stable --path ~/.cache/puppeteer-browsers',
             'The command prints the resolved binary path; export it as CHROME_TEST_PATH.',
-            'e.g. export CHROME_TEST_PATH="$(npx @puppeteer/browsers install chrome@stable | awk \'{print $2}\')"'
+            'e.g. export CHROME_TEST_PATH="$(npx @puppeteer/browsers install chrome@stable --path ~/.cache/puppeteer-browsers | awk \'{print $2}\')"'
           ].join('\n')
         );
         assert(
           process.env.CHROMEDRIVER_TEST_PATH,
           [
             'CHROMEDRIVER_TEST_PATH is not set.',
-            'Install ChromeDriver: npx @puppeteer/browsers install chromedriver@stable',
+            'Install ChromeDriver: npx @puppeteer/browsers install chromedriver@stable --path ~/.cache/puppeteer-browsers',
             'The command prints the resolved binary path; export it as CHROMEDRIVER_TEST_PATH.',
-            'e.g. export CHROMEDRIVER_TEST_PATH="$(npx @puppeteer/browsers install chromedriver@stable | awk \'{print $2}\')"'
+            'e.g. export CHROMEDRIVER_TEST_PATH="$(npx @puppeteer/browsers install chromedriver@stable --path ~/.cache/puppeteer-browsers | awk \'{print $2}\')"'
           ].join('\n')
         );
         const path = process.env.CHROMEDRIVER_TEST_PATH;

--- a/packages/webdriverio/test/axe-webdriverio.spec.ts
+++ b/packages/webdriverio/test/axe-webdriverio.spec.ts
@@ -17,13 +17,7 @@ import { ChildProcessWithoutNullStreams } from 'child_process';
 import { fixturesPath } from 'axe-test-fixtures';
 import sinon from 'sinon';
 
-const {
-  getFreePort,
-  connectToChromeDriver,
-  loadBdmEnv
-} = require('./testUtils');
-
-loadBdmEnv();
+const { getFreePort, connectToChromeDriver } = require('./testUtils');
 
 // devtools protocol was removed in WDIO v9.
 // require('webdriverio/package.json') fails when the package uses an exports
@@ -55,11 +49,11 @@ describe('@axe-core/webdriverio', () => {
         port = await getFreePort();
         assert(
           process.env.CHROME_TEST_PATH,
-          'CHROME_TEST_PATH is not set. Run `npx browser-driver-manager install chrome`'
+          'CHROME_TEST_PATH is not set. Install Chrome and export the path (CI uses browser-actions/setup-chrome).'
         );
         assert(
           process.env.CHROMEDRIVER_TEST_PATH,
-          'CHROMEDRIVER_TEST_PATH is not set. Run `npx browser-driver-manager install chrome`'
+          'CHROMEDRIVER_TEST_PATH is not set. Install ChromeDriver and export the path (CI uses browser-actions/setup-chrome).'
         );
         const path = process.env.CHROMEDRIVER_TEST_PATH;
         chromedriverProcess = child_process.spawn(path as string, [

--- a/packages/webdriverio/test/axe-webdriverio.spec.ts
+++ b/packages/webdriverio/test/axe-webdriverio.spec.ts
@@ -49,11 +49,21 @@ describe('@axe-core/webdriverio', () => {
         port = await getFreePort();
         assert(
           process.env.CHROME_TEST_PATH,
-          'CHROME_TEST_PATH is not set. Install Chrome and export the path (CI uses browser-actions/setup-chrome).'
+          [
+            'CHROME_TEST_PATH is not set.',
+            'Install Chrome: npx @puppeteer/browsers install chrome@stable',
+            'The command prints the resolved binary path; export it as CHROME_TEST_PATH.',
+            'e.g. export CHROME_TEST_PATH="$(npx @puppeteer/browsers install chrome@stable | awk \'{print $2}\')"'
+          ].join('\n')
         );
         assert(
           process.env.CHROMEDRIVER_TEST_PATH,
-          'CHROMEDRIVER_TEST_PATH is not set. Install ChromeDriver and export the path (CI uses browser-actions/setup-chrome).'
+          [
+            'CHROMEDRIVER_TEST_PATH is not set.',
+            'Install ChromeDriver: npx @puppeteer/browsers install chromedriver@stable',
+            'The command prints the resolved binary path; export it as CHROMEDRIVER_TEST_PATH.',
+            'e.g. export CHROMEDRIVER_TEST_PATH="$(npx @puppeteer/browsers install chromedriver@stable | awk \'{print $2}\')"'
+          ].join('\n')
         );
         const path = process.env.CHROMEDRIVER_TEST_PATH;
         chromedriverProcess = child_process.spawn(path as string, [

--- a/packages/webdriverio/test/esmTest.mjs
+++ b/packages/webdriverio/test/esmTest.mjs
@@ -39,7 +39,7 @@ async function integrationTest() {
         browserName: 'chrome',
         'goog:chromeOptions': {
           args: ['--headless', '--no-sandbox'],
-          ...(chromeBinary && { binary: chromeBinary })
+          ...(chromeBinary ? { binary: chromeBinary } : {})
         }
       },
       logLevel: 'error'

--- a/packages/webdriverio/test/esmTest.mjs
+++ b/packages/webdriverio/test/esmTest.mjs
@@ -8,7 +8,10 @@ import { fixturesPath } from 'axe-test-fixtures';
 import { spawn } from 'child_process';
 import { getFreePort, connectToChromeDriver } from './testUtils.js';
 
-const { default: { path: chromedriverPath } } = await import('chromedriver');
+const chromedriverPath =
+  process.env.CHROMEDRIVER_TEST_PATH ||
+  (await import('chromedriver')).default.path;
+const chromeBinary = process.env.CHROME_TEST_PATH;
 
 assert(typeof defaultExport === 'function', 'default export is not a function');
 assert(typeof AxeBuilder === 'function', 'named export is not a function');
@@ -35,7 +38,8 @@ async function integrationTest() {
       capabilities: {
         browserName: 'chrome',
         'goog:chromeOptions': {
-          args: ['--headless', '--no-sandbox']
+          args: ['--headless', '--no-sandbox'],
+          ...(chromeBinary && { binary: chromeBinary })
         }
       },
       logLevel: 'error'

--- a/packages/webdriverio/test/testUtils.js
+++ b/packages/webdriverio/test/testUtils.js
@@ -1,9 +1,6 @@
 'use strict';
 
 const net = require('net');
-const path = require('path');
-const os = require('os');
-const { config } = require('dotenv');
 
 const getFreePort = () => {
   return new Promise((resolve, reject) => {
@@ -47,9 +44,4 @@ const connectToChromeDriver = (port, retries = 10, interval = 200) => {
   return retry(retries);
 };
 
-const loadBdmEnv = () => {
-  const bdmCacheDir = path.resolve(os.homedir(), '.browser-driver-manager');
-  config({ path: path.resolve(bdmCacheDir, '.env') });
-};
-
-module.exports = { getFreePort, connectToChromeDriver, loadBdmEnv };
+module.exports = { getFreePort, connectToChromeDriver };

--- a/packages/webdriverjs/README.md
+++ b/packages/webdriverjs/README.md
@@ -12,7 +12,12 @@ Install [Node.js](https://docs.npmjs.com/getting-started/installing-node) if you
 
 > Download and install any necessary browser drivers on your machine's PATH. [More on Webdriver setup](https://www.selenium.dev/documentation/en/webdriver/).
 
-To install the latest version of Chromedriver globally, install browser-driver-manager: `npm install -g browser-driver-manager`. Then run `npx browser-driver-manager install chrome`.
+To install matched Chrome and ChromeDriver versions, use [`@puppeteer/browsers`](https://pptr.dev/browsers-api):
+
+```
+npx @puppeteer/browsers install chrome@stable
+npx @puppeteer/browsers install chromedriver@stable
+```
 
 Install Selenium Webdriver: `npm install selenium-webdriver`
 

--- a/packages/webdriverjs/README.md
+++ b/packages/webdriverjs/README.md
@@ -12,12 +12,14 @@ Install [Node.js](https://docs.npmjs.com/getting-started/installing-node) if you
 
 > Download and install any necessary browser drivers on your machine's PATH. [More on Webdriver setup](https://www.selenium.dev/documentation/en/webdriver/).
 
-To install matched Chrome and ChromeDriver versions, use [`@puppeteer/browsers`](https://pptr.dev/browsers-api):
+To install matched Chrome and ChromeDriver versions, use [`@puppeteer/browsers`](https://pptr.dev/browsers-api). By default it installs into the current working directory; pass `--path` to keep the binaries in a stable shared location you can reuse across projects (e.g. `~/.cache/puppeteer-browsers`):
 
 ```
-npx @puppeteer/browsers install chrome@stable
-npx @puppeteer/browsers install chromedriver@stable
+npx @puppeteer/browsers install chrome@stable --path ~/.cache/puppeteer-browsers
+npx @puppeteer/browsers install chromedriver@stable --path ~/.cache/puppeteer-browsers
 ```
+
+Each command prints the resolved binary path. Wire **both** into your WebDriver setup — point ChromeDriver via `new chrome.ServiceBuilder(chromedriverPath)` and the Chrome binary via `new chrome.Options().setChromeBinaryPath(chromePath)`. If you only set the ChromeDriver path, ChromeDriver will fall back to your system-installed Chrome, which is almost never the same version and will fail with `session not created`.
 
 Install Selenium Webdriver: `npm install selenium-webdriver`
 

--- a/packages/webdriverjs/error-handling.md
+++ b/packages/webdriverjs/error-handling.md
@@ -10,7 +10,14 @@ Version 4.3.0 and above of the axe-core integrations use a new technique when ca
 
 ### Having an Out-of-date Driver
 
-A common problem is having an out-of-date driver. To fix this issue make sure that your local install of [geckodriver](https://github.com/mozilla/geckodriver/releases) or [chromedriver](https://chromedriver.chromium.org/downloads) is up-to-date.
+A common problem is having an out-of-date driver, or — more often — a driver whose version doesn't match the browser it's driving. To fix this, install a matched Chrome / ChromeDriver pair with [`@puppeteer/browsers`](https://pptr.dev/browsers-api) and point your WebDriver setup at **both** binaries:
+
+```
+npx @puppeteer/browsers install chrome@stable --path ~/.cache/puppeteer-browsers
+npx @puppeteer/browsers install chromedriver@stable --path ~/.cache/puppeteer-browsers
+```
+
+Wire the printed ChromeDriver path into `new chrome.ServiceBuilder(...)` and the printed Chrome path into `new chrome.Options().setChromeBinaryPath(...)`. If you only set the ChromeDriver path, it will fall back to your system Chrome — which almost never matches — and fail with `session not created`. For Firefox, make sure your local install of [geckodriver](https://github.com/mozilla/geckodriver/releases) is up-to-date.
 
 An example error message for this problem will include a message about `switchToWindow`.
 

--- a/packages/webdriverjs/test/test-utils.ts
+++ b/packages/webdriverjs/test/test-utils.ts
@@ -8,18 +8,18 @@ export const Webdriver = (): WebDriver => {
     process.env.CHROME_TEST_PATH,
     [
       'CHROME_TEST_PATH is not set.',
-      'Install Chrome: npx @puppeteer/browsers install chrome@stable',
+      'Install Chrome: npx @puppeteer/browsers install chrome@stable --path ~/.cache/puppeteer-browsers',
       'The command prints the resolved binary path; export it as CHROME_TEST_PATH.',
-      'e.g. export CHROME_TEST_PATH="$(npx @puppeteer/browsers install chrome@stable | awk \'{print $2}\')"'
+      'e.g. export CHROME_TEST_PATH="$(npx @puppeteer/browsers install chrome@stable --path ~/.cache/puppeteer-browsers | awk \'{print $2}\')"'
     ].join('\n')
   );
   assert(
     process.env.CHROMEDRIVER_TEST_PATH,
     [
       'CHROMEDRIVER_TEST_PATH is not set.',
-      'Install ChromeDriver: npx @puppeteer/browsers install chromedriver@stable',
+      'Install ChromeDriver: npx @puppeteer/browsers install chromedriver@stable --path ~/.cache/puppeteer-browsers',
       'The command prints the resolved binary path; export it as CHROMEDRIVER_TEST_PATH.',
-      'e.g. export CHROMEDRIVER_TEST_PATH="$(npx @puppeteer/browsers install chromedriver@stable | awk \'{print $2}\')"'
+      'e.g. export CHROMEDRIVER_TEST_PATH="$(npx @puppeteer/browsers install chromedriver@stable --path ~/.cache/puppeteer-browsers | awk \'{print $2}\')"'
     ].join('\n')
   );
   // Weird type change since 4.23.1 release

--- a/packages/webdriverjs/test/test-utils.ts
+++ b/packages/webdriverjs/test/test-utils.ts
@@ -6,11 +6,21 @@ import { assert } from 'chai';
 export const Webdriver = (): WebDriver => {
   assert(
     process.env.CHROME_TEST_PATH,
-    'CHROME_TEST_PATH is not set. Install Chrome and export the path (CI uses browser-actions/setup-chrome).'
+    [
+      'CHROME_TEST_PATH is not set.',
+      'Install Chrome: npx @puppeteer/browsers install chrome@stable',
+      'The command prints the resolved binary path; export it as CHROME_TEST_PATH.',
+      'e.g. export CHROME_TEST_PATH="$(npx @puppeteer/browsers install chrome@stable | awk \'{print $2}\')"'
+    ].join('\n')
   );
   assert(
     process.env.CHROMEDRIVER_TEST_PATH,
-    'CHROMEDRIVER_TEST_PATH is not set. Install ChromeDriver and export the path (CI uses browser-actions/setup-chrome).'
+    [
+      'CHROMEDRIVER_TEST_PATH is not set.',
+      'Install ChromeDriver: npx @puppeteer/browsers install chromedriver@stable',
+      'The command prints the resolved binary path; export it as CHROMEDRIVER_TEST_PATH.',
+      'e.g. export CHROMEDRIVER_TEST_PATH="$(npx @puppeteer/browsers install chromedriver@stable | awk \'{print $2}\')"'
+    ].join('\n')
   );
   // Weird type change since 4.23.1 release
   // @see https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/69724

--- a/packages/webdriverjs/test/test-utils.ts
+++ b/packages/webdriverjs/test/test-utils.ts
@@ -1,24 +1,16 @@
 import { WebDriver, Builder } from 'selenium-webdriver';
 import chrome from 'selenium-webdriver/chrome';
 import firefox from 'selenium-webdriver/firefox';
-import { config } from 'dotenv';
-import os from 'os';
-import path from 'path';
 import { assert } from 'chai';
-
-const HOME_DIR = os.homedir();
-const BDM_CACHE_DIR = path.resolve(HOME_DIR, '.browser-driver-manager');
-
-config({ path: path.resolve(BDM_CACHE_DIR, '.env') });
 
 export const Webdriver = (): WebDriver => {
   assert(
     process.env.CHROME_TEST_PATH,
-    'CHROME_TEST_PATH is not set. Run `npx browser-driver-manager install chrome`'
+    'CHROME_TEST_PATH is not set. Install Chrome and export the path (CI uses browser-actions/setup-chrome).'
   );
   assert(
     process.env.CHROMEDRIVER_TEST_PATH,
-    'CHROMEDRIVER_TEST_PATH is not set. Run `npx browser-driver-manager install chrome`'
+    'CHROMEDRIVER_TEST_PATH is not set. Install ChromeDriver and export the path (CI uses browser-actions/setup-chrome).'
   );
   // Weird type change since 4.23.1 release
   // @see https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/69724

--- a/test/wdio/wdio.conf.ts
+++ b/test/wdio/wdio.conf.ts
@@ -62,7 +62,13 @@ export const config: Options.Testrunner = {
       // capabilities for local browser web tests
       browserName: 'chrome', // or "firefox", "microsoftedge", "safari"
       'goog:chromeOptions': {
-        args: ['--headless'],
+        args: [
+          '--headless',
+          // Required for CI runners using >=Ubuntu 24.04
+          // @see https://github.com/SeleniumHQ/selenium/issues/14609
+          '--no-sandbox',
+          '--disable-dev-shm-usage'
+        ],
         ...(process.env.CHROME_TEST_PATH && {
           binary: process.env.CHROME_TEST_PATH
         })

--- a/test/wdio/wdio.conf.ts
+++ b/test/wdio/wdio.conf.ts
@@ -62,7 +62,10 @@ export const config: Options.Testrunner = {
       // capabilities for local browser web tests
       browserName: 'chrome', // or "firefox", "microsoftedge", "safari"
       'goog:chromeOptions': {
-        args: ['--headless']
+        args: ['--headless'],
+        ...(process.env.CHROME_TEST_PATH && {
+          binary: process.env.CHROME_TEST_PATH
+        })
       }
     }
   ],

--- a/test/wdio/wdio.conf.ts
+++ b/test/wdio/wdio.conf.ts
@@ -69,9 +69,9 @@ export const config: Options.Testrunner = {
           '--no-sandbox',
           '--disable-dev-shm-usage'
         ],
-        ...(process.env.CHROME_TEST_PATH && {
-          binary: process.env.CHROME_TEST_PATH
-        })
+        ...(process.env.CHROME_TEST_PATH
+          ? { binary: process.env.CHROME_TEST_PATH }
+          : {})
       }
     }
   ],


### PR DESCRIPTION
## Summary

- Drops `browser-driver-manager` in favor of `browser-actions/setup-chrome` across every browser job in `tests.yml`. Default Chrome is `stable`, but the `CHROME_VERSION` GitHub repository variable can pin a version when needed.
- Standardizes Chrome / ChromeDriver discovery in every suite around two env vars: `CHROME_TEST_PATH` and `CHROMEDRIVER_TEST_PATH`. They are populated by the action and exported via `$GITHUB_ENV`.
- Fixes the failing `webdriverio` `test:export` job: `test/esmTest.mjs` now reads both env vars, so the spawned ChromeDriver and the launched Chrome come from the same `setup-chrome` install instead of mixing the pinned `chromedriver@^146` against whatever Chrome the runner image happens to ship (148 today).

### Per-suite changes
- **webdriverio**: removes the `loadBdmEnv` dotenv loader; `axe-webdriverio.spec.ts` and `test/esmTest.mjs` consume `CHROME_TEST_PATH` / `CHROMEDRIVER_TEST_PATH` directly.
- **webdriverjs**: drops the BDM cache-dir dotenv loader from `test-utils.ts`.
- **cli**: now reads `CHROME_TEST_PATH` / `CHROMEDRIVER_TEST_PATH` directly from `process.env`. The legacy BDM `~/.browser-driver-manager/.env` auto-load is preserved as a silent back-compat shim — see **Backwards compatibility** below. Existing `--chrome-path` / `--chromedriver-path` CLI flags and the `chromedriver` npm fallback are untouched.
- **puppeteer**: `puppeteerOpts()` and `test/esmTest.mjs` now set `executablePath` from `CHROME_TEST_PATH` when present.
- **playwright**: `chromium.launch()` conditionally takes `executablePath` from `CHROME_TEST_PATH`.
- **test/wdio**: `goog:chromeOptions.binary` is set from `CHROME_TEST_PATH` when present.

### Workflow changes (`.github/workflows/tests.yml`)
- Six jobs (`puppeteer`, `cli`, `webdriverjs`, `webdriverio`, `playwright`, `wdio_globals_test`) now run:
  ```yaml
  - uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2.1.2
    id: setup-chrome
    with:
      chrome-version: ${{ vars.CHROME_VERSION || 'stable' }}
      install-chromedriver: true
      install-dependencies: true
  - run: |
      echo "CHROME_TEST_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> "$GITHUB_ENV"
      echo "CHROMEDRIVER_TEST_PATH=${{ steps.setup-chrome.outputs.chromedriver-path }}" >> "$GITHUB_ENV"
  ```
- The Playwright job drops `npx playwright install --with-deps` since `install-dependencies: true` on `setup-chrome` covers the OS libs and Playwright launches our binary via `executablePath`.
- Root `browser-driver-manager` dep removed; `package-lock.json` refreshed.

### Public-facing documentation

Brings user-facing install guidance in line with the `@puppeteer/browsers` recommendation that test-assertion messages already use:

- `packages/cli/README.md`, `packages/webdriverjs/README.md`, `packages/webdriverio/README.md`, `packages/webdriverjs/error-handling.md`, `packages/webdriverio/error-handling.md`: BDM install instructions replaced with `npx @puppeteer/browsers install chrome@stable --path ~/.cache/puppeteer-browsers` (and the equivalent chromedriver command). The `--path` keeps binaries in a stable shared location instead of polluting whatever directory `npx` happens to be invoked from.
- Docs now also explain why callers must supply **both** the Chrome and ChromeDriver paths (either via `--chrome-path`/`--chromedriver-path` for the CLI or the equivalent setup-builder calls in the library packages): if only the new ChromeDriver is wired up, it auto-discovers the system Chrome — which almost never matches the new ChromeDriver version — and fails with `session not created`.
- `packages/cli/src/bin/index.ts:134-143`: the `SessionNotCreatedError` "ChromeDriver only supports" branch now recommends `npx @puppeteer/browsers install … --path ~/.cache/puppeteer-browsers` and instructs users to pass both `--chrome-path` and `--chromedriver-path`. Same trigger, same `process.exit(2)`; only the help text was updated.

### Backwards compatibility

Earlier versions of `@axe-core/cli` documented `browser-driver-manager` (BDM) as the install path and silently auto-loaded the env-var paths BDM wrote to `~/.browser-driver-manager/.env`. To avoid silently breaking existing users on that flow:

- BDM is no longer mentioned anywhere we surface — READMEs, runtime errors, error-handling docs, and test-setup assertions all point at `@puppeteer/browsers`.
- The CLI still auto-loads `~/.browser-driver-manager/.env` on startup if it exists (with `quiet: true` so it's a no-op when the file's absent). `dotenv` remains a CLI dependency for this shim only. `dotenv` doesn't override entries already in `process.env`, so shell-exported values and explicit flags always win.

Net effect: any setup that worked on `develop` keeps working on this branch. The other shipped packages (`@axe-core/{webdriverjs,webdriverio,puppeteer,playwright}`) only had test files and docs touched — no `src/` changes, no public API surface change.

No QA Required
