### PR TITLE
ci: increase timeout for axe-core update

### DIFF
--- a/.github/workflows/update-axe-core.yml
+++ b/.github/workflows/update-axe-core.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6.0.2
       - uses: actions/setup-node@v6


### PR DESCRIPTION
It needs more juice.

No QA Required