### PR TITLE
chore: group browser-driver and jest deps for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -78,6 +78,70 @@ updates:
           - 'major'
           - 'minor'
           - 'patch'
+      # Keep the Jest toolchain in lockstep so the runner, its environments,
+      # and the TypeScript transform always land with the jest major they
+      # require.
+      # Enumerate by exact name — glob patterns have been unreliable here.
+      # If you add a new jest-* dep anywhere in this repo, append it here.
+      jest:
+        patterns:
+          - 'jest'
+          - 'jest-environment-jsdom'
+          - 'ts-jest'
+        update-types:
+          - 'major'
+          - 'minor'
+          - 'patch'
+      # Browser-driver integrations: keep each framework and its directly
+      # related packages (types, scoped sub-packages, protocol shims) moving
+      # in lockstep, including majors, so a framework major never lands
+      # without its companion packages.
+      # Enumerate by exact name — glob patterns have been unreliable here.
+      # If you add a new package for one of these frameworks, append it here.
+      selenium:
+        patterns:
+          - 'selenium-webdriver'
+          - '@types/selenium-webdriver'
+        update-types:
+          - 'major'
+          - 'minor'
+          - 'patch'
+      webdriverio:
+        patterns:
+          - 'webdriverio'
+          - '@wdio/globals'
+          - 'devtools'
+        update-types:
+          - 'major'
+          - 'minor'
+          - 'patch'
+      playwright:
+        patterns:
+          - 'playwright'
+          - 'playwright-core'
+          - '@playwright/test'
+        update-types:
+          - 'major'
+          - 'minor'
+          - 'patch'
+      puppeteer:
+        patterns:
+          - 'puppeteer'
+          - 'puppeteer-core'
+        update-types:
+          - 'major'
+          - 'minor'
+          - 'patch'
+      # Standalone browser-driver binaries shared across the selenium and
+      # webdriverio integrations, so they belong to neither framework group.
+      browser-drivers:
+        patterns:
+          - 'chromedriver'
+          - 'geckodriver'
+        update-types:
+          - 'major'
+          - 'minor'
+          - 'patch'
       # Any updates not caught by the group config will get individual PRs
       npm-low-risk:
         update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -78,9 +78,11 @@ updates:
           - 'major'
           - 'minor'
           - 'patch'
-      # Keep the Jest toolchain in lockstep so the runner, its environments,
-      # and the TypeScript transform always land with the jest major they
-      # require.
+      # Batch the Jest toolchain into one PR so the runner, its environment,
+      # and the TypeScript transform update together. Covers majors so a
+      # future jest major doesn't ship without the environment/transform
+      # updates it needs. Grouping batches the PRs; it does not by itself
+      # guarantee peer-compatible versions, so sanity-check a jest major bump.
       # Enumerate by exact name — glob patterns have been unreliable here.
       # If you add a new jest-* dep anywhere in this repo, append it here.
       jest:
@@ -117,8 +119,6 @@ updates:
           - 'patch'
       playwright:
         patterns:
-          - 'playwright'
-          - 'playwright-core'
           - '@playwright/test'
         update-types:
           - 'major'
@@ -127,17 +127,17 @@ updates:
       puppeteer:
         patterns:
           - 'puppeteer'
-          - 'puppeteer-core'
         update-types:
           - 'major'
           - 'minor'
           - 'patch'
-      # Standalone browser-driver binaries shared across the selenium and
-      # webdriverio integrations, so they belong to neither framework group.
+      # The chromedriver binary and its types are used by the cli (selenium)
+      # and webdriverio packages, so they belong to neither framework group;
+      # keep the binary and its @types package landing together.
       browser-drivers:
         patterns:
           - 'chromedriver'
-          - 'geckodriver'
+          - '@types/chromedriver'
         update-types:
           - 'major'
           - 'minor'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -111,7 +111,11 @@ updates:
       webdriverio:
         patterns:
           - 'webdriverio'
+          - '@wdio/cli'
           - '@wdio/globals'
+          - '@wdio/local-runner'
+          - '@wdio/mocha-framework'
+          - '@wdio/spec-reporter'
           - 'devtools'
         update-types:
           - 'major'


### PR DESCRIPTION
Add Dependabot grouping rules under the npm package-ecosystem so the
browser-driver integration frameworks and the Jest toolchain each update
together instead of arriving as scattered individual PRs.

Six new groups are added, each enumerating exact package names (no glob
patterns, which have been unreliable in this repo) and covering major,
minor, and patch updates:

- **jest** — `jest`, `jest-environment-jsdom`, `ts-jest`
- **selenium** — `selenium-webdriver`, `@types/selenium-webdriver`
- **webdriverio** — `webdriverio`, `@wdio/cli`, `@wdio/globals`,
  `@wdio/local-runner`, `@wdio/mocha-framework`, `@wdio/spec-reporter`,
  `devtools`
- **playwright** — `@playwright/test`
- **puppeteer** — `puppeteer`
- **browser-drivers** — `chromedriver`, `@types/chromedriver`

`chromedriver` (and its `@types/chromedriver` companion) is used by the
cli and webdriverio packages, so it goes in its own browser-drivers group
rather than being forced into a single framework's group.

Each group includes major updates so a framework major never lands
without its companion packages (for example a webdriverio major arriving
without its `@wdio/*` companions). Exact names are listed rather than
wildcards because glob patterns have not behaved reliably here, matching
the convention already established by the eslint group; the trade-off is
that new framework packages must be appended by hand, which fails safe to
the npm-low-risk group or an individual PR if missed.

Only packages that are actually direct dependencies Dependabot manages are
listed. Speculative entries (`geckodriver`, `puppeteer-core`,
`playwright-core`, and a bare `playwright`) are deliberately excluded:
`geckodriver` and `puppeteer-core` are not dependencies anywhere,
`playwright-core` is only a peerDependency (which Dependabot does not
update), and bare `playwright` lives only in the workspace-excluded
`test/release`.

No QA Required