### PR TITLE
docs(webdriverjs): update chrome options in example

### DIFF
--- a/packages/webdriverjs/README.md
+++ b/packages/webdriverjs/README.md
@@ -30,9 +30,13 @@ const { Builder } = require('selenium-webdriver');
 const chrome = require('selenium-webdriver/chrome');
 
 (async () => {
+  const options = new chrome.Options();
+
+  options.addArguments('headless');
+
   const driver = new Builder()
     .forBrowser('chrome')
-    .setChromeOptions(new chrome.Options().headless())
+    .setChromeOptions(options)
     .build();
   await driver.get('https://dequeuniversity.com/demo/mars/');
 


### PR DESCRIPTION
The latest version of `selenium-webdriver` does not have the `headless` function.

No QA Required