### PR TITLE
ci: remove scheduled trigger from update-axe-core workflow

### DIFF
--- a/.github/workflows/update-axe-core.yml
+++ b/.github/workflows/update-axe-core.yml
@@ -1,9 +1,6 @@
 name: Update axe-core
 
 on:
-  schedule:
-    # Run every night at midnight
-    - cron: '0 0 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Removes the nightly `schedule` trigger from the axe-core update workflow.

axe-core updates are moving to manual, centralized dispatch, so each repository no longer needs its own cron.
The workflow is unchanged otherwise and still runs on `workflow_dispatch`.

No QA needed
