### PR TITLE
feat: update axe-core to v4.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9217,9 +9217,9 @@
       "link": true
     },
     "node_modules/axe-core": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
-      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
@@ -27437,8 +27437,8 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@axe-core/webdriverjs": "^4.12.1",
-        "axe-core": "~4.12.1",
-        "chromedriver": "*",
+        "axe-core": "~4.13.0",
+        "chromedriver": "latest",
         "colors": "^1.4.0",
         "commander": "^9.4.1",
         "dotenv": "^17.2.2",
@@ -27470,7 +27470,7 @@
       "version": "4.12.1",
       "license": "MPL-2.0",
       "dependencies": {
-        "axe-core": "~4.12.1"
+        "axe-core": "~4.13.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.60.0",
@@ -27495,7 +27495,7 @@
       "version": "4.12.1",
       "license": "MPL-2.0",
       "dependencies": {
-        "axe-core": "~4.12.1"
+        "axe-core": "~4.13.0"
       },
       "devDependencies": {
         "@types/chai": "^4.3.3",
@@ -27526,7 +27526,7 @@
       "version": "4.12.1",
       "license": "MPL-2.0",
       "dependencies": {
-        "axe-core": "~4.12.1",
+        "axe-core": "~4.13.0",
         "requestidlecallback": "^0.3.0"
       },
       "devDependencies": {
@@ -27559,7 +27559,7 @@
       "devDependencies": {
         "@types/clone": "^2.1.1",
         "@types/jsonld": "github:types/jsonld",
-        "axe-core": "~4.12.1",
+        "axe-core": "~4.13.0",
         "clone": "^2.1.2",
         "jest": "^30.0.5",
         "jest-environment-jsdom": "^30.1.2",
@@ -27573,7 +27573,7 @@
       "version": "4.12.1",
       "license": "MPL-2.0",
       "dependencies": {
-        "axe-core": "~4.12.1",
+        "axe-core": "~4.13.0",
         "cssesc": "^3.0.0"
       },
       "devDependencies": {
@@ -28017,7 +28017,7 @@
       "version": "4.12.1",
       "license": "MPL-2.0",
       "dependencies": {
-        "axe-core": "~4.12.1"
+        "axe-core": "~4.13.0"
       },
       "devDependencies": {
         "@types/chai": "^4.3.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,7 +48,7 @@
   ],
   "dependencies": {
     "@axe-core/webdriverjs": "^4.12.1",
-    "axe-core": "~4.12.1",
+    "axe-core": "~4.13.0",
     "chromedriver": "latest",
     "colors": "^1.4.0",
     "commander": "^9.4.1",

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -51,7 +51,7 @@
     "prepare": "npx playwright install && npm run build"
   },
   "dependencies": {
-    "axe-core": "~4.12.1"
+    "axe-core": "~4.13.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -52,7 +52,7 @@
     "tsup": "^8.0.1"
   },
   "dependencies": {
-    "axe-core": "~4.12.1"
+    "axe-core": "~4.13.0"
   },
   "peerDependencies": {
     "puppeteer": ">=1.10.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -60,7 +60,7 @@
   "author": "Dylan Barrell (dylan@barrell.com)",
   "license": "MPL-2.0",
   "dependencies": {
-    "axe-core": "~4.12.1",
+    "axe-core": "~4.13.0",
     "requestidlecallback": "^0.3.0"
   },
   "devDependencies": {

--- a/packages/reporter-earl/package.json
+++ b/packages/reporter-earl/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@types/clone": "^2.1.1",
     "@types/jsonld": "github:types/jsonld",
-    "axe-core": "~4.12.1",
+    "axe-core": "~4.13.0",
     "clone": "^2.1.2",
     "jest": "^30.0.5",
     "jest-environment-jsdom": "^30.1.2",

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -48,7 +48,7 @@
     "webdriverio"
   ],
   "dependencies": {
-    "axe-core": "~4.12.1",
+    "axe-core": "~4.13.0",
     "cssesc": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/webdriverjs/package.json
+++ b/packages/webdriverjs/package.json
@@ -84,7 +84,7 @@
     "tsup": "^8.0.1"
   },
   "dependencies": {
-    "axe-core": "~4.12.1"
+    "axe-core": "~4.13.0"
   },
   "peerDependencies": {
     "selenium-webdriver": ">3.0.0-beta  || >=2.53.1 || >4.0.0-alpha"


### PR DESCRIPTION
Updates `axe-core` to v4.13.0.

Opened automatically by [ocarina-team](https://github.com/dequelabs/ocarina-team) via workflow run: https://github.com/dequelabs/ocarina-team/actions/runs/31401719283

Fixes: #1412