### PR TITLE
ci: create the release tag when publishing to production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,7 +91,7 @@ jobs:
     permissions:
       # Required for OIDC
       id-token: write
-      contents: read
+      contents: write # create the release tag
     if: github.ref_name == 'master' && github.repository_owner == 'dequelabs'
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -115,11 +115,14 @@ jobs:
           npx lerna publish from-package \
             --force-publish='*' \
             --yes
-      - run: |
+      # Nothing tags the release commit beforehand, so `gh release create` creates
+      # the tag at --target and the notes come from merged PRs rather than the tag.
+      - name: Create GitHub release
+        run: |
           PKG_VERSION=$(jq -r .version < lerna.json)
-          gh release create v$PKG_VERSION \
+          gh release create "v$PKG_VERSION" \
             --title "Release $PKG_VERSION" \
-            --notes-from-tag \
-            --target master
+            --generate-notes \
+            --target "$GITHUB_SHA"
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Problem

The production `Deploy` job's final step has failed on **every** release since v4.11.0:

```
cannot generate release notes from tag v4.13.0 as it does not exist locally
##[error]Process completed with exit code 1
```

Runs: [v4.13.0](https://github.com/dequelabs/axe-core-npm/actions/runs/31515664375), [v4.12.1](https://github.com/dequelabs/axe-core-npm/actions/runs/28037100897), [v4.11.3](https://github.com/dequelabs/axe-core-npm/actions/runs/25161892807), [v4.11.2](https://github.com/dequelabs/axe-core-npm/actions/runs/24567463371), [v4.11.1](https://github.com/dequelabs/axe-core-npm/actions/runs/21642701479), [v4.11.0](https://github.com/dequelabs/axe-core-npm/actions/runs/18691499897).

The npm publish itself succeeded every time — only the GitHub release step broke, so the tags and releases have been created by hand after the fact.

`gh release create --notes-from-tag` reads the annotated tag's message out of the local clone, but no tag exists at that point:

- `lerna publish from-package` only publishes the versions already in `package.json`; it does not version or tag.
- `actions/checkout` runs at the default `fetch-depth: 1` with no `fetch-tags`, so even an existing remote tag would not be in the clone.

The job also declared `contents: read`, so fixing the tag lookup alone would have moved the failure to a 403 on release creation.

## Fix

- `--notes-from-tag` → `--generate-notes`, building notes from merged PRs instead of a tag message. This matches how the notes on the existing v4.11.x releases were actually written.
- `--target master` → `--target "$GITHUB_SHA"`, so `gh release create` creates the tag at the exact commit that was published rather than wherever `master` has drifted to.
- `contents: read` → `contents: write` on the production job, required to create the tag.

Pushing an annotated tag in a separate step and keeping `--notes-from-tag` was the alternative — more moving parts for the same outcome.

## Note

v4.13.0 was published to npm successfully but had no release. I created [`v4.13.0`](https://github.com/dequelabs/axe-core-npm/releases/tag/v4.13.0) manually at `70dca94` with the same `--generate-notes` this PR switches to, so the release history is current. **v4.12.0 and v4.12.1 are still missing releases** and should be backfilled separately if we want them.


Re-running a partially-failed deploy will now error on the duplicate tag rather than silently no-op. Since we tag after deploy, this shouldn't impact anything. We will close the gap later as we harden all these workflows more.


No QA Required
